### PR TITLE
Upgrade the guide and client to ACME v2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
-ruby '2.3.1'
+ruby '2.7.1'
 
-gem 'httparty', '~> 0.14'
-gem 'nitlink', '~> 1.0'
-gem 'dnsimple', '~> 2.2'
-gem 'net-scp', '~> 1.2.1'
+gem 'httparty', '~> 0.18'
+gem 'dnsimple', '~> 4.6'
+gem 'net-scp', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,29 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    dnsimple (4.6.0)
+      httparty
+    httparty (0.18.0)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2020.0425)
+    multi_xml (0.6.0)
+    net-scp (3.0.0)
+      net-ssh (>= 2.6.5, < 7.0.0)
+    net-ssh (6.0.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  dnsimple (~> 4.6)
+  httparty (~> 0.18)
+  net-scp (~> 3.0)
+
+RUBY VERSION
+   ruby 2.7.1p83
+
+BUNDLED WITH
+   2.1.4

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Alex Peattie
+Copyright (c) 2020 Alex Peattie
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -817,7 +817,7 @@ We can see our `"identifier"` is echoed back to us, along with the authorization
 - Provisioning a special DNS record for `dns-01`
 - Offering a specified temporary certificate for `tns-alpn-01` (not covered in this guide)
 
-When we created our `newOrder` we mentioned we'd be given one authorization URL for each identifier we provided. For the main tutorial we'll only handle the client sending a single domain/identifier (hence `order['authorizations'].first`) - see [Appendix 4](http://localhost:8887/#appendix-4-multiple-subdomains) for how we can extend our client to handle multiple identifiers. Next, we'll pick out our HTTP and DNS challenges:
+When we created our `newOrder` we mentioned we'd be given one authorization URL for each identifier we provided. For the main tutorial we'll only handle the client sending a single domain/identifier (hence `order['authorizations'].first`) - see [Appendix 4](#appendix-4-multiple-subdomains) for how we can extend our client to handle multiple identifiers. Next, we'll pick out our HTTP and DNS challenges:
 
 ```ruby
 challenges = signed_request(order['authorizations'].first, kid: kid)['challenges']
@@ -1133,7 +1133,7 @@ server {
 }
 ```
 
-That's theoretically all we need, but we can improve on nginx's defaults for better security and performance. We'll use the settings recommended by <https://cipherli.st/> (click "Yes, give me a ciphersuite that works with legacy / old software." if you need to support older browsers) and a couple of extra headers recommended by [securityheaders.io](https://securityheaders.io/). We'll use Google's DNS server (8.8.8.8) as our `resolver` (recommended for [OSCP stapling](https://en.wikipedia.org/wiki/OCSP_stapling) on nginx):
+That's theoretically all we need, but we can improve on nginx's defaults for better security and performance. We'll use the settings recommended by <https://syslink.pl/cipherlist/> (click "Yes, give me a ciphersuite that works with legacy / old software." if you need to support older browsers) and a couple of extra headers recommended by [securityheaders.io](https://securityheaders.io/). We'll use Google's DNS server (8.8.8.8) as our `resolver` (recommended for [OSCP stapling](https://en.wikipedia.org/wiki/OCSP_stapling) on nginx):
 
 ```nginx
 ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
@@ -1157,7 +1157,7 @@ add_header Content-Security-Policy "default-src https: data: 'unsafe-inline' 'un
 
 We should keep the line enabling the `Strict-Transport-Security` header commented out until we're happy our HTTPS setup is working (as visitor's won't be able to access our non-HTTPS site once it's activated).
 
-We can harden our configuration by dropping support for TLS < v1.2 - although that does have implications for [supporting older browsers](https://en.wikipedia.org/wiki/Template:TLS/SSL_support_history_of_web_browsers). If we happy to target just older browsers, we should also allow only cipher suites with a minimum 256-bit key length for AES (the symmetric cipher):
+We can harden our configuration by dropping support for TLS < v1.2 - although that does have implications for [supporting older browsers](https://en.wikipedia.org/wiki/Transport_Layer_Security#Web_browsers). If we happy to target just older browsers, we should also allow only cipher suites with a minimum 256-bit key length for AES (the symmetric cipher):
 
 ```nginx
 ssl_protocols TLSv1.2;
@@ -1262,7 +1262,6 @@ Some other useful testing tools:
 
 - [revocationcheck.com](https://certificate.revocationcheck.com/) - Useful for debugging OSCP
 - [testssl.sh](https://testssl.sh/) and [cipherscan](https://github.com/jvehent/cipherscan) - Command line TLS testing tools
-- [SSL Decoder](https://ssldecoder.org) - Open-source tool for checking SSL/TLS config - gives lots of info, but no score per se.
 - [High-Tech Bridge SSL Server Security Test](https://www.htbridge.com/ssl/) - A decent alternative to SSL Labs's tool. Advocates weaker ciphers because of HIPAA guidance though.
 
 <br>
@@ -1448,7 +1447,7 @@ Broadly-speaking key size means how hard a key is to crack. Longer keys offer mo
 
 We don't have a very broad choice when it comes to choosing key size. 2048 bits has effectively been an [enforced minimum](https://www.cabforum.org/wp-content/uploads/Baseline_Requirements_V1.pdf) since the beginning of 2014; 4096 bits is the upper bound. 4096 bits is favored by some, but is far from the standard right now. It's anticipated that 2048-bit keys will be considered secure [until about 2030](http://www.keylength.com/en/4/).
 
-2048 is the default key size for [certbot](https://github.com/certbot/certbot#current-features). But you will need a 4096 bit key to score perfectly on the Key [SSL Labs' test](https://www.ssllabs.com/downloads/SSL_Server_Rating_Guide.pdf), and there are lively discussions advocating the LE default be raised to [4096](https://github.com/certbot/certbot/issues/489) or [3072](https://github.com/certbot/certbot/issues/2080). CertSimple did an [awesome, detailed rundown](https://certsimple.com/blog/measuring-ssl-rsa-keys) of the benefits of different key sizes, and basically concluded "it depends".
+2048 is the default key size for [certbot](https://github.com/certbot/certbot#current-features). But you will need a 4096 bit key to score perfectly on the Key [SSL Labs' test](https://github.com/ssllabs/research/wiki/SSL-Server-Rating-Guide), and there are lively discussions advocating the LE default be raised to [4096](https://github.com/certbot/certbot/issues/489) or [3072](https://github.com/certbot/certbot/issues/2080). CertSimple did an [awesome, detailed rundown](https://certsimple.com/blog/measuring-ssl-rsa-keys) of the benefits of different key sizes, and basically concluded "it depends".
 
 We will need a key size of 4096 bits to get a perfect SSL Labs score. Not all cloud providers support key sizes above 2048 bits though, AWS CloudFront being a notable example. If you want or need to use a 2048-bit key, you can specify the key length like so:
 
@@ -1869,10 +1868,10 @@ In other words, you'll need to create a new account, pass the challenges for the
 #### TLS/SSL in general
 
 - [Bulletproof SSL and TLS](https://www.feistyduck.com/books/bulletproof-ssl-and-tls/) - wonderful ~500 page book, goes into great detail about everything you might want to know about SSL/TLS
-- [SSL/TLS Deployment Best Practices (PDF)](https://www.ssllabs.com/downloads/SSL_TLS_Deployment_Best_Practices.pdf) - By the same author as *Bulletproof*, a quick 10 page checklist
+- [SSL/TLS Deployment Best Practices](https://github.com/ssllabs/research/wiki/SSL-and-TLS-Deployment-Best-Practices) - By the same author as *Bulletproof*, an up-to-date and thorough checklist
 - [TLS chapter in High Performance Browser Networking](http://chimera.labs.oreilly.com/books/1230000000545/ch04.html) - like the TL;DR of *Bulletproof*, covers all the fundamentals, plus more recent developments like OCSP stapling, HSTS etc.
 - [OWASP's TLS Cheat Sheet](https://www.owasp.org/index.php/Transport_Layer_Protection_Cheat_Sheet) - An excellent list of do's and don't relating to SSL/TLS
-- [Modern SSL/TLS Best Practices for Fast, Secure Websites](http://www.scmagazine.com/resource-library/resource/cloudflare/whitepaper/56cb65bced344a22f86cb85d/) (PDF, registration required) - decent white paper, with loads of visuals, up-to-date best practice recommendations
+- [Modern SSL/TLS Best Practices for Fast, Secure Websites](https://www.infosecurity-magazine.com/white-papers/ssltls-best-practices/) (PDF, registration required) - decent white paper, with loads of visuals, up-to-date best practice recommendations
 - [SSL Best Practices: a Quick and Dirty Guide](https://www.ssl.com/guide/ssl-best-practices-a-quick-and-dirty-guide/) - top-level, reasonably recent (2015) best practices guide.
 - [How does SSL/TLS work?](http://security.stackexchange.com/questions/20803/how-does-ssl-tls-work/20833#20833) - Good StackExchange answer
 - [TLS in HTTP/2](https://daniel.haxx.se/blog/2015/03/06/tls-in-http2/)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The guide and client code are all [MIT licensed](https://github.com/alexpeattie/
 
 #### Technology
 
-This example code is written in Ruby (I used 2.3), and is largely dependency free (apart from OpenSSL). We use [HTTParty](https://github.com/jnunemaker/httparty) and [Nitlink](https://github.com/alexpeattie/nitlink) for more convenient API requests - but you could use vanilla `Net::HTTP` if you're a masochist :see_no_evil:. And we'll use additional gems to upload files and provision DNS records.
+This example code is written in Ruby (I used 2.3), and is largely dependency free (apart from OpenSSL). We use [HTTParty](https://github.com/jnunemaker/httparty) for more convenient API requests - but you could use vanilla `Net::HTTP` if you're a masochist :see_no_evil:. And we'll use additional gems to upload files and provision DNS records.
 
 The choice of language is meant to be a background factor - the guide is (hopefully) illustrative & understandable even if you're not familiar with/interested in Ruby.
 
@@ -108,7 +108,7 @@ client_key = OpenSSL::PKey::RSA.new(IO.read(client_key_path), 'letmein')
 
 The first, and probably hardest step, is constructing requests in the very particular format that Let's Encrypt demands. It's important to remember though, that in principle, the Let's Encrypt API is the same as any other API.
 
-For example, using the [Github API](https://developer.github.com/v3/) I can programatically create an issue, by making a `POST` request to the target repo's `/issues` endpoint with a JSON payload that includes the issue title and body:
+For example, using the <a href='https://developer.github.com/v3/' name='github-example'>Github API</a> I can programatically create an issue, by making a `POST` request to the target repo's `/issues` endpoint with a JSON payload that includes the issue title and body:
 
 ```json
 POST https://api.github.com/repos/alexpeattie/letsencrypt-fromscratch/issues
@@ -122,30 +122,48 @@ POST https://api.github.com/repos/alexpeattie/letsencrypt-fromscratch/issues
 The key difference with the Let's Encrypt API is we can't just send our JSON payload in a nice human-readable format as above, because we'll be signing it with our client private key to prove our identity. This is what a request to the Let's Encrypt API looks like:
 
 ```json
-POST https://acme-v01.api.letsencrypt.org/acme/new-cert
+POST https://acme-staging-v02.api.letsencrypt.org/acme/new-acct
 
 {
   "payload": "eyJyZXNvdXJjZSI6Im5ldy1jZXJ0IiwiY3NyIjoiTUlJRVhEQ0NBa1FDQVFBd0Z6RVZNQk1HQTFVRUF3d01abWxzWlhNdWNHVm5MbU52TUlJQ0lqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FnOEFNSUlDQ2dLQ0FnRUE2ZG9JNWdlc1VWZVV2czJXN1h3LV9JcDg2eFl3ZnV0MDVNWE1aYWpWa3lMS1lhNHpjdGs3Y2hIN1ZuQWsxVF9uTXNaM0hYTlQ3X0J0R1hkYnlJR0FqRXhpR3F4cm5LejJqSS1JTVRNU1RKSklmRVhDUVJqUkx2U0c2S3VYbXk2aGhkS3BLMkpRam10OTh0QmxUY0NxbFFKNGRZWV9oMVFCTmYwZmUwN3p4T24zUXlaeU9Da05GMkdGQmZoSWZqTGRuVXJCbDBSejlTSUhLZkZTWW13SldKMTBBLWJiNVdRM2FkUWlNWF83amhYWHVBdUdDZnRBZ2h1UGdPWjlTalJXYVBpalNkOUxERWk1Y2pCalFsN1o4a0ZKTnV0VndSQlNFTDFIQVVNWE9ndkxKLW5mVjV4Tm15VHdmYTRsdXV4WEtsVnpJZFlmZDRUZWV1NHhwUTAxb29vQ0dLRUVCZ3VMQzdQLUtjemg4MUxXaTZtcExIRVZwOTNzWi1QZDZvNlROMFlabVZjaUwtNlJpTGRXY2hUeEtkbjNvTS1UYmRBTUVxb3VmTU5JYkh6LUVHREFxUkhGOUxCTU43bFlPcWJ0dWFmcjduN1EtVmQxN19KTGIxcnpONVFmclZvd2o4cUJpUHlRUndXbDhqN2hiLVpCR1NpMlJNb0V3LWNURG1KYjIweWUwQXZrWHhqVmxqbTN1aGpWVWRHTEtTQ0dfM1I4V0VuWEI3akRTV3Zpd0NEdDFKLWtPSW5EOEVUcjFvVDJKWWJ5N0FsaS12R25jdjJRdlhSb010RG9MN3F0MmkzSHNNZzhORjFDSHVhRUQ3RXdiTEMwRTRpWnZfcUw2WW45endqMVZ2bUZtbjA3T1ItanVOYkFnUXAtb01XR1lORDFKMnRpSW5QV0RtVUNBd0VBQWFBQU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQ0FRREdPdjUxc1hlUWNSLVhYMmUtbDZfSEt1WjNfVTdKbTJmNWtMMWJvbkpwOUM0UExacVNZMzNDZE5FbE1BcEVRczFzLTVhWEJCemRYWWE1X05hTFB2cm5fRm5mb2d1cnJHOXV6cU1vT0QtMjMtUnd5QkNLZFpNQ3gyVmd0YWNFU3RiZ2RLamNMRnRNRVE4YnR1NHIxMXVKQWlrblRIQnk4V3ZmaHREVS1Da0FkT2FYZV8zMktKSVV4Z05LSzhiYnRVUGlFc21jd3VqUGVzUkprWUh1QWVKc2JFQkY5ekVZNjlCazZiZVZKUUpxRjR4VjhYYmJheGZSX1N6TG5NWnJZNFhoNDNXbGRPN1UzZm9BZHYtLWk3eTlDbDUxaTJRV1RZMHFGcGVmd19nUU93SFFWMW9BRWJ0OWwyYkgyNGEtZ2NKUE9RNEhTdTBEV0ZHaFdSVkVuMUJsQ01XMkxGQnp2elpzMGdIaFhnQ1psVnNGcE1nYndJMThBLTA4UjZvS2FRWC1fM2tDb0FIaXcxQ1pdanaVQ1ZVOVRZNXNUMVlnZXBJVzBkT0VHYXY3YUJMXzNCbk9HVzVlMlZ2LXN5aGVSZS1ORzhXTEZiOHRyc2hMYTRPOVVjS3h3Nzl0MjFGaEhUYXhIblJLcDhFR3p3M2ZoZElMUW42YVlkb0k4Wm9faGJJaUE0cEhoMXlCbGpLU2Q3Zk1xTzkzX3JxV2Y4NzRfd2Q4N3RhcDFmb1pyZ1dYMVU5Wm9ZUnhFZ0FQOVN1cUdrcTJVUl9ucU9CQl9XaVBPM2ZGcFc3cTB6UEp1QUtBNWZIdDdFRG1HUldkTWNGXzM0SDdNenZPQk4tckI2S3VZTUtzWXpkS1ZEMDhwUnhUVVhKc3Nrb2t2MVF3aGNmNklzdEFtMDJ6bjhfWHBRIn0",
-  "header": {
-    "alg": "RS256",
-    "jwk": {
-      "e": "AQAB",
-      "kty": "RSA",
-      "n": "xVZG_h6B314tV_UNG-KUA_wldRuRjXvdcLwwtzOSBBjA1aGa-wabVUjazf2DrPWHlhiFlfom0sV0JgR2Ak5Ydlr4OOTqWCQ6m-ABnl71DvUs-u8eQwcLPsp-ccmRW3vYGuXoSP7-TEM9MSfAI-jeJ9vXeyDUGQDTD1FcBcZh886tR6LwyHBUbE0aD7I5I6pKr5kn24utnXcQ0LNoTOwjycexwzb-kGYHKfHdK5Chx1XLUkZIw7SYqePTchcBRsn6WOYLZ-orT4G58CRNbqpWa6qeRDijCOguUZfaJPuZLJl8ULIhtim0k1Y2e-X8tCNn-qacraicW6mPdlRcBUXAzQ"
-    }
-  },
   "protected": "eyJhbGciOiJSUzI1NiIsImp3ayI6eyJlIjoiQVFBQiIsImt0eTI6IlJTQSIsIm4iOiJ4VlpHX2g2QjMxNHRWX1VORy1LVUFfd2xkUnVSalh2ZGNMd3d0ek9TQkJqQTFhR2Etd2FiVlVqYXpmMkRyUFdIbGhpRmxmb20wc1YwSmdSMkFrNVlkbHI0T09UcVdDUTZtLTRMbmw3MUR2VXMtdThlUXdjTFBzcC1jY21SVzN2WUd1WG9TUDctVEVNOU1TZkFJLWplSjl2WGV5RFVHUURURDFGY0JjWmg4ODZ0UjZMd3lIQlViRTBhRDdJNUk2cEtyNWtuMjR1dG5YY1EwTE5vVE93anljZAv3emIta0dZSEtmSGRLNUNoeDFYTFVrWkl3N1NZcWVQVGNoY0JSc242V09ZTFotb3JUNEc1OENTTmJxcFdhNnFlUkRpakPNZ3VVWmZhSlB1WkxKbDhVTElodGltMGsxWTJlLVg4dENObi1xYWNyYWljVzZtUGRsUmNCVVhBelEifSwibm9uY2UiOiJidGY3SFpROHlvVERGNVphWjdaSnVGR05tOWR2cWhyNmdWVHR0NHZYbmFvIn0",
   "signature": "Mo1ZVEkT_QjsH4Yy98tTm3JEpsccnriVn5L18yjN2O1ea57V3apkDkkMb_3wleJ0YJskSuNrvtftJOC_-OqeT1_qbq4AjugEqMPle5I7VUAzshnh1DL7YiAgds5Fm06VtCuWUns5owF2MtVmjKMJHdHc9a_9-jilQsFWrTHEZgTt_ebBHazFpiEVcqoNCxhho-XxWZaHlvDOncJXUnqG0SWIa0OeM5Gm80jlPRlQoE5Wp6RqQvn1Fsb3NpzMUEQwD-s9JCvB4U2tQdpGLM5ynfbFwlgyS1AgKiQ4FLEftc55Yo9yOo0bXEugM7aDZS7-_TjqFD_N7r0IJHPp8fXrCQ"
 }
 ```
 
-This is what's called a JWS (JSON Web Signature), specifically a ["JWS Using Flattened JWS JSON Serialization"](https://tools.ietf.org/html/rfc7515#appendix-A.7) from [RFC 7515](https://tools.ietf.org/html/rfc7515). Scary stuff eh :ghost:? Don't worry, we'll break down the anatomy of this strange looking request in the sections below.
+This is what's called a JWS (JSON Web Signature), specifically a variant of ["JWS Using Flattened JWS JSON Serialization"](https://tools.ietf.org/html/rfc7515#appendix-A.7) from [RFC 7515](https://tools.ietf.org/html/rfc7515). Scary stuff eh :ghost:?
+
+Don't worry, it's not really as intimidating as it looks. In this section we'll explain the anatomy of these curious looking requests, and write code to make them ourselves.
 
 <br>
 
-#### a. Base64 all the things
+#### a. The anatomy of a Let's Encrypt request
 
-One problem we'll run into is that when we sign our payload with our key, we might not get ASCII out, even if we're only putting ASCII in. We can see this for ourselves:
+Let's look at our request again, this time, I'll truncate the encoded data a bit for readability:
+
+```json
+POST https://acme-staging-v02.api.letsencrypt.org/acme/new-acct
+
+{
+  "payload": "eyJyZXNvdXJjZSI6Im5ldy1jZ...",
+  "protected": "eyJhbGciOiJSUzI1NiIsImp3a...",
+  "signature": "Mo1ZVEkT_QjsH4Yy98tTm3JEp..."
+}
+```
+
+Notice that we have three keys in the JSON we're `POST`ing to Let's Encrypt: `"payload"`, `"protected"` and `"signature"`. All requests we send to LE will contain only these keys, which each serve a distinct role.
+
+**`"payload"`**, as the name, implies is where the 'meat' of the request goes. Remember our [Github example](#user-content-github-example), where we provided the title and body of the issue we were creating? This is the kind of that goes into payload. If we're registering an account, the payload will contain our registration details (email, name, contact details etc.). If we're ordering a certificate, the payload will contain the domain names we're looking to secure.
+
+**`"protected"`** is short for 'integrity-protected header'; this is where we include some important metadata. First we confirm the **URL** we're requesting and include a **nonce** (see part d) - this makes it difficult for an attacker to try and redirect or replay our requests. We also include details about our **public key** - either by sending the important parts of the key in a special format, or a unique ID for the key which LE keeps on file. LE will then use the public key to verify the...
+
+**`"signature"`** - this simply takes the previous two parts of the request (`"payload"` and `"protected"`), and cryptographically signs them. This means that if an attacker was to intercept our attack, change an element of the payload or header, then forward on the request, LE will recognize the tampering and reject the request.
+
+<br>
+
+#### b. Base64 all the things
+
+One problem we'll run into is that when we sign our payload and header with our key, we might not get ASCII out, even if we're only putting ASCII in. We can see this for ourselves:
 
 ```ruby
 puts client_key.sign OpenSSL::Digest::SHA256.new, 'Hello world'
@@ -186,24 +204,26 @@ def base64_le(data)
 end
 ```
 
+A quick sidenote: Base64 is just encoding, not encryption. It's not meant to keep the details of our request secret, it's really just to avoid headaches with character encodings.
+
 <br>
 
-#### b. Payload
+#### c. Payload
 
-The **payload** is the simplest part of our request. It's just JSON that we'll Base64 encode using our method above:
+The **payload** will differ for each request - it's where we put any information that's important for the request we're making (e.g. our email address when we register a new account). The good news is that we simple apply our Base64 encoding and we're done:
 
 ```ruby
-base64_le '{"resource":"new-reg"}'
- #=> "eyJyZXNvdXJjZSI6ICJuZXctcmVnIn0"
+base64_le '{"contact":["mailto:me@alexpeattie.com"]}'
+ #=> "eyJjb250YWN0IjpbIm1haWx0bzptZUBhbGV4cGVhdHRpZS5jb20iXX0"
  ```
 
-This a totally valid payload that we can send to Let's Encrypt. Obviously it'll be more convienient not to have to construct JSON strings by hand - so let's load in the [JSON library](http://ruby-doc.org/stdlib-2.3.0/libdoc/json/rdoc/JSON.html) (again part of the Ruby standard lib):
+This a totally valid payload that we can send to Let's Encrypt. Obviously it'll be more convenient not to have to construct JSON strings by hand - so let's load in the [JSON library](http://ruby-doc.org/stdlib-2.3.0/libdoc/json/rdoc/JSON.html) (again part of the Ruby standard lib):
 
 ```ruby
 require 'json'
 
-base64_le JSON.dump(resource: 'new-reg')
- #=> "eyJyZXNvdXJjZSI6ICJuZXctcmVnIn0"
+base64_le JSON.dump(contact: ['mailto:me@alexpeattie.com'])
+ #=> "eyJjb250YWN0IjpbIm1haWx0bzptZUBhbGV4cGVhdHRpZS5jb20iXX0"
 ```
 
 For further convenience, we can make our Base64 helper method smarter. If the data we pass in is an array or hash, it should JSONify the data before encoding it:
@@ -215,53 +235,100 @@ def base64_le(data)
 end
 ```
 
-That's all we need for our payload :smile:! As well as providing information about the request we want to make, it will form one half of the data we'll be signing.
+That's all we need for our payload :smile:! As well as providing information about the request we want to make, the payload will form one half of the data we'll be signing.
 
 <br>
 
-#### c. Header
+#### d. Protected header
 
-We'll need to give Let's Encrypt two things for it to validate the authenticity of the request: our public key, and the cryptographic hashing algorithm we're using to generate the signature. This info will go in our **header**.
+We'll need to give Let's Encrypt two things for it to validate the authenticity of the request: our public key, and the cryptographic hashing algorithm we're using to generate the signature.
 
-The static parts of our header are as follows:
+The protected header is where we include metadata which allows Let's Encrypt to validate the authenticity of our request, and makes the request more difficult forge, replay or redirect.
 
-```ruby
-header = {
-  alg: 'RS256',
-  jwk: {
-    kty: 'RSA',
-  }
-}
-```
-
-`alg` corresponds with the hashing algorithm we want to use - in this case SHA-256 (or more technically [RSA PKCS#1 v1.5 signature with SHA-256](https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-14#section-3.1), but we don't really have to worry about that here). `kty` means key type - our keys are RSA keys. `jwk` stands for JSON web key - a standard for sharing keys via JSON.
-
-The parts of the key we're interested in are the public key exponent (e) and the modulus (n). Helpfully our `client_key` has corresponding methods (`client_key.e` and `client_key.n`) - the only additionally steps we need to take are converting them to binary strings with `to_s(2)` ([documented here](http://ruby-doc.org/stdlib-2.3.0/libdoc/openssl/rdoc/OpenSSL/BN.html#to_s-method)), then (you guessed it), Base64 encoding them. Let's also create a `header` convenience method:
+In the next section, we'll cryptographically sign our payload and header, to protect our request from tampering. The first thing we'll need to do is give LE a heads-up as to the particular signing algorithm we're planning to use. We'll use the RSA with SHA-256 algorithm (or more formally, [RSA PKCS#1 v1.5 signature with SHA-256](https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-14#section-3.1)) - we specify this choice with the `alg` key:
 
 ```ruby
-def header
-  {
-    alg: 'RS256',
-    jwk: {
-      e: base64_le(client_key.e.to_s(2)),
-      kty: 'RSA',
-      n: base64_le(client_key.n.to_s(2)),
-    }
+def protected_header
+  metadata = {
+    alg: 'RS256'
   }
+
+  base64_le(metadata)
 end
 ```
 
+(Currently LE [supports](https://github.com/letsencrypt/boulder/issues/1191#issuecomment-228087035) a few other signing algorithms: `ES256`, `ES384` and `ES512` - but `RS256` is by far the most popular choice. If you're interested in using elliptic curve signature algorithms - the `ES*` family - see [Appendix 7](#appendix-7-using-ec-client-keys)).
+
+Our choice of signing algorithm is one half of what LE will need to verify our signature - the other half is the **public part of our signing key**. There are two ways we'll bundle our public key into our protected header. When we set up our account for the first time, we'll send our public key as a JSON web key (JWK). JWK is a widely-used [standard] for sharing keys via JSON. Once we've registered our account and public key, LE will give use a unique key ID which we can use to reference our public key (which LE will store). For all subsequent requests, we'll just reference this key ID (`kid`).
+
+(Note: the use of `kid` is one of the major departures from ACME v1. In v1 we'd send our JWK with each request).
+
+Let's start with sending our public key as a JWK (which we'll do during account creation). The parts of the key we're interested in are the public key exponent (e) and the modulus (n). Helpfully our `client_key` has corresponding methods (`client_key.e` and `client_key.n`) - the only additionally steps we need to take are converting them to binary strings with `to_s(2)` ([documented here](http://ruby-doc.org/stdlib-2.3.0/libdoc/openssl/rdoc/OpenSSL/BN.html#to_s-method)), then (you guessed it), Base64 encoding them.
+
+We'll additionally have to specify the key type (`kty`) of `client_key` - in our case, it's an RSA key. We'll wrap everything in a `jwk` convenience method:
+
+```ruby
+def jwk
+  {
+    e: base64_le(client_key.e.to_s(2)),
+    kty: 'RSA',
+    n: base64_le(client_key.n.to_s(2)),
+  }
+end
+
+def protected_header
+  metadata = {
+    alg: 'RS256',
+    jwk: jwk
+  }
+
+  base64_le(metadata)
+end
+```
+
+We can now send our public key in JWK format - but (typically) we'll only do this once. After creating our account, we'll need to instead use the unique key ID that LE will assign to our stored public key. When we pass this `kid`, we provide it in place of our `jwk`:
+
+```ruby
+def protected_header(kid = nil)
+  metadata = { alg: 'RS256' }
+
+  if kid
+    metadata.merge!({ kid: kid })
+  else
+    metadata.merge!({ jwk: jwk })
+  end
+
+  return base64_le(metadata)
+end
+```
+
+Another important piece of metadata is the URL we're requesting - this will prevent an attacker from trying to sneakily redirect our request to another Let's Encrypt URL without the server noticing:
+
+```ruby
+def protected_header(url, kid = nil)
+  metadata = { alg: 'RS256', url: url }
+
+  if kid
+    metadata.merge!({ kid: kid })
+  else
+    metadata.merge!({ jwk: jwk })
+  end
+
+  return base64_le(metadata)
+end
+```
+
+We're almost done, but there's one additional preventative method we'll use to protect against would-be attackers :japanese_ogre:...
+
 <br>
 
-#### d. Protected header and the nonce
+#### d. The nonce
 
-We have our plaintext header - which contains the required components of our public key. We'll also need a **protected header** - basically a Base64 encoded version of our header which will form the other half of the data we'll be signing (alongside our payload).
-
-The protected header contains one additional element which our unprotected header doesn't - a [cryptographic nonce](https://en.wikipedia.org/wiki/Cryptographic_nonce). The linked article goes into lots of details, but a nonce is basically a one-time use code which we must attach to our request. It means if an attacker somehow sniffs out a request we made, and makes a carbon-copy duplicate request, the attackers attempt will fail (because the nonce has already been used).
+To protect against replay attacks, we'll add in a [cryptographic nonce](https://en.wikipedia.org/wiki/Cryptographic_nonce). The linked articles go into lots of detail, but a nonce is basically a one-time use code which we must attach to our request. It means if an attacker somehow sniffs out a request we made, and makes a carbon-copy duplicate request, the attackers attempt will fail (because the nonce has already been used).
 
 <p align='center'><img src='https://user-images.githubusercontent.com/636814/27398616-34eb14c0-56b2-11e7-8582-aee497307088.gif' width='350'></p>
 
-Let's Encrypt provides us a nonce in the headers of every response it gives us - so getting a nonce is just a case of requesting any Let's Encrypt API endpoint, and grabbing it from the `Replay-Nonce` header.
+Let's Encrypt provides us a nonce in the `Replay-Nonce` header of every request, so an efficient approach would be to save the nonce from each request, and use it for the subsequent one. LE also gives us a dedicated endpoint for fetching a new nonce (`/acme/new-nonce`) , so a lazier (but simpler) approach is to fetch fresh nonces from here for each request.
 
 Ruby comes with the `Net::HTTP` library built in for making HTTP requests, but it's a bit cumbersome. To make our life easier, we'll use [HTTParty](https://github.com/jnunemaker/httparty) - although this is by no means a necessity.
 
@@ -281,23 +348,37 @@ We'll send HTTParty's debug output to `$stdout` so we can see easily see the req
 HTTParty::Basement.default_options.update(debug_output: $stdout)
 ```
 
-As mentioned above, any Let's Encrypt API endpoint will do - let's use the `/directory` endpoint (effectively the root of the API). Because we only need the headers, we can just make a `HEAD` request:
+Now we're ready to make a request to the new nonce endpoint. Because we only need the headers, we can just make a `HEAD` request:
 
 ```ruby
-nonce = HTTParty.head('https://acme-v01.api.letsencrypt.org/directory')['Replay-Nonce']
+def nonce
+  HTTParty.head('https://acme-staging-v02.api.letsencrypt.org/acme/new-nonce')['Replay-Nonce']
+end
 ```
 
-We can now create our protected header:
+(I'm hard-coding the new nonce endpoint here, which is bad practice :speak_no_evil:. Don't worry, I'll fix it part g.)
+
+This gives us the final piece of our integrity protected header:
 
 ```ruby
-protected = base64_le(header.merge(nonce: nonce))
+def protected_header(url, kid = nil)
+  metadata = { alg: 'RS256', nonce: nonce, url: url }
+
+  if kid
+    metadata.merge!({ kid: kid })
+  else
+    metadata.merge!({ jwk: jwk })
+  end
+
+  return base64_le(metadata)
+end
 ```
 
 <br>
 
 #### e. Signature
 
-The last step to construct our request is proving its authenticity with a **signature**, generated using our *client private key*. First, let's consolidate everything we have so far:
+The last step to construct our request is to prove its authenticity with a **signature**, generated using our *client private key*. First, let's consolidate everything we have so far:
 
 ```ruby
 require 'openssl'
@@ -313,23 +394,35 @@ end
 client_key_path = File.expand_path('~/.ssh/id_rsa')
 client_key = OpenSSL::PKey::RSA.new IO.read(client_key_path)
 
-payload = { some: 'data'}
+payload = { some: 'data' }
 
-header = {
-  alg: 'RS256',
-  jwk: {
+def jwk
+  {
     e: base64_le(client_key.e.to_s(2)),
     kty: 'RSA',
     n: base64_le(client_key.n.to_s(2)),
   }
-}
+end
 
-nonce = HTTParty.head('https://acme-v01.api.letsencrypt.org/directory')['Replay-Nonce']
+def protected_header(url, kid = nil)
+  metadata = { alg: 'RS256', nonce: nonce, url: url }
+
+  if kid
+    metadata.merge!({ kid: kid })
+  else
+    metadata.merge!({ jwk: jwk })
+  end
+
+  return base64_le(metadata)
+end
+
+def nonce
+  HTTParty.head('https://acme-staging-v02.api.letsencrypt.org/acme/new-nonce')['Replay-Nonce']
+end
 
 request = {
   payload: base64_le(payload),
-  header: header,
-  protected: base64_le(header.merge(nonce: nonce))
+  protected: protected_header('/some-url')
 }
 ```
 
@@ -339,7 +432,7 @@ As mentioned [above](#c-header), we'll be using the SHA-256 hash function for ou
 hash_algo = OpenSSL::Digest::SHA256.new
 ```
 
-The specific data we'll need to sign is our protected header and our payload, joined with a period:
+The specific data we'll need to sign is simply our protected header and our payload, joined with a period:
 
 ```ruby
 request[:signature] = client_key.sign(hash_algo, [ request[:protected], request[:payload] ].join('.'))
@@ -355,7 +448,7 @@ Now we've built the request data just as Let's Encrypt wants, we have everything
 HTTParty.post(some_api_endpoint, body: JSON.dump(request))
 ```
 
-Let's put everything into a reusable method that can take an arbitrary URL and payload. (We'll move `client_key`, `hash_algo`, `header` and `nonce` into methods at the same time):
+Let's put everything into a reusable method that can take an arbitrary URL and payload. (We'll move `client_key` and `hash_algo` into methods at the same time):
 
 ```ruby
 HTTParty::Basement.default_options.update(debug_output: $stdout)
@@ -382,17 +475,36 @@ def hash_algo
   OpenSSL::Digest::SHA256.new
 end
 
-def nonce
-  HTTParty.head('https://acme-v01.api.letsencrypt.org/directory')['Replay-Nonce']
+def jwk
+  {
+    e: base64_le(client_key.e.to_s(2)),
+    kty: 'RSA',
+    n: base64_le(client_key.n.to_s(2)),
+  }
 end
 
-def signed_request(url, payload)
+def protected_header(url, kid = nil)
+  metadata = { alg: 'RS256', nonce: nonce, url: url }
+
+  if kid
+    metadata.merge!({ kid: kid })
+  else
+    metadata.merge!({ jwk: jwk })
+  end
+
+  return base64_le(metadata)
+end
+
+def nonce
+  HTTParty.head('https://acme-staging-v02.api.letsencrypt.org/acme/new-nonce')['Replay-Nonce']
+end
+
+def signed_request(url, payload, kid = nil)
   request = {
     payload: base64_le(payload),
-    header: header,
-    protected: base64_le(header.merge(nonce: nonce))
+    protected: protected_header(url, kid)
   }
-  request[:signature] = client_key.sign(hash_algo, [ request[:protected], request[:payload] ].join('.'))
+  request[:signature] = base64_le client_key.sign(hash_algo, [request[:protected], request[:payload]].join('.'))
 
   HTTParty.post(url, body: JSON.dump(request))
 end
@@ -401,56 +513,50 @@ end
 
 #### g. Fetching the endpoints
 
-The `/directory` endpoint that we use to fetch our nonce serves another purpose: it lists all the other endpoints which act as the starting points for all the core actions (registering a user, authorizing a domain, issuing a certificate etc.):
+I mentioned above that we should avoid hard-coding the URLs our client uses - the best-practice is to instead a special `/directory` endpoint. This directory lists all the key endpoints we'll need to get started with our key actions (registering a user, authorizing a domain, issuing a certificate etc.):
 
 ```json
 {
-  "key-change": "https://acme-v01.api.letsencrypt.org/acme/key-change",
+  "keyChange": "https://acme-staging-v02.api.letsencrypt.org/acme/key-change",
   "meta": {
-    "terms-of-service": "https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf"
+    "termsOfService": "https://letsencrypt.org/documents/LE-SA-v1.2-November-15-2017.pdf"
   },
-  "new-authz": "https://acme-v01.api.letsencrypt.org/acme/new-authz",
-  "new-cert": "https://acme-v01.api.letsencrypt.org/acme/new-cert",
-  "new-reg": "https://acme-v01.api.letsencrypt.org/acme/new-reg",
-  "revoke-cert": "https://acme-v01.api.letsencrypt.org/acme/revoke-cert"
+  "newAccount": "https://acme-staging-v02.api.letsencrypt.org/acme/new-acct",
+  "newNonce": "https://acme-staging-v02.api.letsencrypt.org/acme/new-nonce",
+  "newOrder": "https://acme-staging-v02.api.letsencrypt.org/acme/new-order",
+  "revokeCert": "https://acme-staging-v02.api.letsencrypt.org/acme/revoke-cert",
+  "z93cEwMHcG8": "https://community.letsencrypt.org/t/adding-random-entries-to-the-directory/33417"
 }
 ```
 
-(Note: unlike the API's endpoints, the directory is viewable without any kind of signing, you can just visit it [in your browser](https://acme-staging.api.letsencrypt.org/directory)).
+(Note: unlike most of the API's endpoints, the directory is viewable without any kind of special signed request, you can just visit it [in your browser](https://acme-staging-v02.api.letsencrypt.org)).
 
-Here the keys in the JSON object indicate the resource type, and the values are the URI we'll need to make a signed request to. Even though [Cool URIs don't change](https://www.w3.org/Provider/Style/URI), using the directory means we don't have to hard-code the endpoints - and so our client is more resilient to any changes Let's Encrypt might make (credit to [@kelunik](https://github.com/kelunik) for suggesting this).
+The camel-cased keys in the JSON object indicate the action (`newAccount` for account registration, `newOrder` to order a certificate etc.), and the values are the URI we'll need to make a signed request to. Even though [Cool URIs don't change](https://www.w3.org/Provider/Style/URI), using the directory means we don't have to hard-code the endpoints - and so our client is more resilient to any changes Let's Encrypt might make (credit to [@kelunik](https://github.com/kelunik) for suggesting this).
 
 To avoid making repeated requests to the directory, let's make an `endpoints` method:
 
 ```ruby
 def endpoints
-  @endpoints ||= HTTParty.get('https://acme-v01.api.letsencrypt.org/directory').to_h
+  @endpoints ||= HTTParty.get('https://acme-staging-v02.api.letsencrypt.org/directory').to_h
 end
 ```
 
-Since we're referencing the directory endpoint in both our `endpoints` and `nonce` methods, we can dry up our code by moving it into a constant. This will also make it easier to, for example, switch to LE's [staging server](https://acme-staging.api.letsencrypt.org/).
+I like to move the directory URI into a constant, to make it clear that this value shouldn't be changed at runtime:
 
 ```ruby
-DIRECTORY_URI = 'https://acme-v01.api.letsencrypt.org/directory'.freeze
-
-def nonce
-  HTTParty.head(DIRECTORY_URI)['Replay-Nonce']
-end
+DIRECTORY_URI = 'https://acme-staging-v02.api.letsencrypt.org/directory'.freeze
 
 def endpoints
   @endpoints ||= HTTParty.get(DIRECTORY_URI).to_h
 end
+
+def nonce
+  HTTParty.head(endpoints['newNonce'])['Replay-Nonce']
+end
+
 ```
 
-The neat thing is that this `DIRECTORY_URI` is the only URI we need to hardcode, every other endpoint we can either pull from the directory, or from the `Location` or `Link` headers of the API's responses. `Location` is easy to work with (it's just a single URI) - but `Link` headers need to be parsed. I've written a gem ([Nitlink](https://github.com/alexpeattie/nitlink)) for just that - so let's install and load it:
-
-```shell
-gem install nitlink
-```
-
-```ruby
-require 'nitlink/response'
-```
+The neat thing is that this `DIRECTORY_URI` is the only URI we need to hard-code; every other endpoint we can either pull from the directory, or from the `Location` headers of the API's responses.
 
 <br>
 
@@ -458,22 +564,41 @@ require 'nitlink/response'
 
 OK, we've laid the foundations - let's make our first actual request to the Let's Encrypt API! The first step is to register our client public key with Let's Encrypt.
 
-Since we're sending the public key with every request (in the `header` property of our JSON), we don't need to include much in the actual registration payload. At a minimum, we'll just need to specify the resource type: `new-reg` in this case.
+First, we should ensure the user has read and accepted the Let's Encrypt [Terms of Service](https://letsencrypt.org/documents/LE-SA-v1.2-November-15-2017.pdf). We can skip this skip if we want to be naughty, but [per the ACME spec](https://tools.ietf.org/html/draft-ietf-acme-acme-09#section-7.3):
+
+> Clients SHOULD NOT automatically agree to terms by default.  Rather, they SHOULD require some user interaction for agreement to terms.
+
+For our user interaction, we'll just print the ToS URL and get the user to confirm they're happy. We can grab the latest terms URL from the directory (under `meta.termsOfService`):
 
 ```ruby
-new_registration = signed_request(endpoints['new-reg'], {
-  resource: 'new-reg',
+tos_url = endpoints['meta']['termsOfService']
+accept_tos = "N"
+until accept_tos == "Y"
+  puts "Do you accept the LetsEncrypt terms? (#{ tos_url })"
+  accept_tos = gets.upcase.chars.first
+end
+```
+
+On to account creation! Since we're sending the public key with every request (in the `header` property of our JSON), we don't need to include much to register an account. In fact, we can register a valid account by just indicating that we accept the ToS:
+
+```ruby
+new_registration = signed_request(endpoints['newAccount'], {
+  termsOfServiceAgreed: true
 })
 ```
 
-We can optionally provide contact details (highly recommended), this will allow us to recover our key in case we lose it. We'll need to include the protocols for the contact details we provide - e.g. `mailto:` for email addresses, <strike>`tel:` for phone numbers</strike> (it turns out Let's Encrypt doesn't currently support this, see [here](https://github.com/letsencrypt/boulder/blob/release/docs/acme-divergences.md#section-62)).
+(Unsurprisingly, if `termsOfServiceAgreed` is anything other than `true`, we'll get a rejection).
+
+We can optionally provide contact details (highly recommended), this will allow us to recover our key in case we lose it. We'll need to include the protocols for the contact details we provide, namely `mailto:` for email addresses (which is all that ACME/LE currently supports).
 
 ```ruby
-new_registration = signed_request(endpoints['new-reg'], {
-  resource: 'new-reg',
+new_registration = signed_request(endpoints['newAccount'], {
+  termsOfServiceAgreed: true,
   contact: ['mailto:me@alexpeattie.com']
 })
 ```
+
+Note that Let's Encrypt will validate the domain the email address belongs to, so a made-up email address will trigger a rejection.
 
 <br>
 
@@ -528,33 +653,6 @@ If we try and register the same key again we'll get a 409 (Conflict) response:
 ```
 
 Don't worry, there are no side effects to attempting to re-register the same client key multiple times :relaxed:.
-
-#### Accepting the ToS
-
-Although we've successfully registered, Let's Encrypt won't let us do anything useful (like issue a certificate), until we accept their [Subscriber Agreement](https://letsencrypt.org/repository/#lets-encrypt-subscriber-agreement).
-
-To indicate our acceptance, we just need to make a request to the URI of our newly created user (returned in the response's `Location` header, in this case `https://acme-v01.api.letsencrypt.org/acme/reg/12345`) with the payload's `agreement` key set to the URI of the terms we're accepting. How do we know the URI of the terms? Eagle-eyed readers might have spotted above that it's returned as one of the response's `Link` headers:
-
-```
-Link: ... <https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf>;rel="terms-of-service"
-```
-
-**Update August 2017:** The URL of the current terms are now also available through the directory, and thus via our `endpoints` method, specifically `endpoints['meta']['terms-of-service']`.
-
-<br>
-
-We should also check that we got a 201 status (not a Conflict or malformed registration). Our final code for accepting the terms programatically looks like this:
-
-```ruby
-if new_registration.status == 201
-  signed_request(new_registration.headers['Location'], {
-    resource: 'reg',
-    agreement: new_registration.links.by_rel('terms-of-service').target
-  })
-end
-```
-
-(The `.links` method depends on the [Nitlink](https://github.com/alexpeattie/nitlink) gem, we'll get a `NoMethodError` if it's not installed). Notice that the resource type has changed, since we're not creating a new user, but modifying an existing one. Also, a real client should probably prompt the user to actually read the agreement - rather than just auto-accepting it :innocent:!
 
 <br>
 
@@ -882,7 +980,7 @@ certificate = OpenSSL::X509::Certificate.new(certificate_response.body)
 
 #### Adding intermediates
 
-We also need to complete our trust chain, which means grabbing the LetsEncrypt cross-signed intermediate certificate (see <https://letsencrypt.org/certificates/>). Some browsers will resolve an incomplete trust chain, but it's something we want to avoid. There's much more info on why we need to complete this step and the difference between the different intermediates LE offers in [Appendix 2: The trust chain & intermediate certificates](#appendix-2-the-trust-chain--intermediate-certificates).
+We also need to complete our trust chain, which means grabbing the Let's Encrypt cross-signed intermediate certificate (see <https://letsencrypt.org/certificates/>). Some browsers will resolve an incomplete trust chain, but it's something we want to avoid. There's much more info on why we need to complete this step and the difference between the different intermediates LE offers in [Appendix 2: The trust chain & intermediate certificates](#appendix-2-the-trust-chain--intermediate-certificates).
 
 Occasionally server software might want us to provide our intermediate certificates separately, but generally we'll bundle them together in a single file. Helpfully, LE provides a link to the latest intermediate certificate in the certificate response's `Link` header (it has the relation type `"up"`):
 
@@ -1301,7 +1399,7 @@ domain = SimpleIDN.to_unicode('müller.de')
 
 ## Appendix 7: Using EC client keys
 
-As well as support ECDSA-based certificates (see above), since 2016 LetsEncrypt has supported ECDSA for client (A.K.A account) keys. We'll have to make a few non-trivial modifications to our client to get EC client keys working though.
+As well as support ECDSA-based certificates (see above), since 2016 Let's Encrypt has supported ECDSA for client (A.K.A account) keys. We'll have to make a few non-trivial modifications to our client to get EC client keys working though.
 
 First, we'll need an EC keypair:
 
@@ -1538,7 +1636,7 @@ end
 
 A fun factoid: Let's Encrypt certificates are technically only valid of 89 days and 23 hours, not for a whole 90 days. This is because LE [backdates certificates by 1 hour](https://github.com/letsencrypt/boulder/blob/3431acfb9236de32c1da2e8eb626b6667e33872c/test/config-next/ca.json#L54) to ensure the certificates can be validated immediately by clients whose clocks might be slightly out. Therefore a certificate issued on August 1st 12:34 will expire October 30th 11:34.
 
-The validity period for Lets Encrypt certificates are relatively short. Per the CA/Browser Forum [Baseline Requirements](https://cabforum.org/wp-content/uploads/CA-Browser-Forum-BR-1.4.8.pdf), Section 6.3.2:
+The validity period for Let's Encrypt certificates are relatively short. Per the CA/Browser Forum [Baseline Requirements](https://cabforum.org/wp-content/uploads/CA-Browser-Forum-BR-1.4.8.pdf), Section 6.3.2:
 
 > Subscriber Certificates issued after 1 March 2018 MUST have a Validity Period no greater than 825 days.
 > Subscriber Certificates issued after 1 July 2016 but prior to 1 March 2018 MUST have a Validity Period no greater than 39 months.
@@ -1619,7 +1717,7 @@ Note that if it's been 30 days since you issued the certificate, the account key
 
 #### Scenario 3: You don't have access to the client key for the account which issued the certificate, or the private key for the domain, but you still control the certificate's domain(s)
 
-Per LetsEncrypt's [article on revocation](https://letsencrypt.org/docs/revoking/):
+Per Let's Encrypt's [article on revocation](https://letsencrypt.org/docs/revoking/):
 
 > If someone issued a certificate after compromising your host or your DNS, you’ll want to revoke that certificate once you regain control. In order to revoke the certificate, Let’s Encrypt will need to ensure that you control the domain names in that certificate (otherwise people could revoke each other’s certificates without permission)! To validate this control, Let’s Encrypt uses the same methods it uses to validate control for issuance: you can put a value in a DNS TXT record, put a file on an HTTP server, or offer a special TLS certificate.
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 
 This is a (pretty detailed) how-to on building a simple ACME client from scratch, able to issue real certificates from [Let's Encrypt](https://letsencrypt.org). I've skipped things like error handling, object orientedness, tests - but not much tweaking would be needed for the client to be production-ready.
 
-The code for the finished client is in [`client.rb`](https://github.com/alexpeattie/letsencrypt-fromscratch/blob/master/client.rb).
+The code for the finished client is in [`client.rb`](https://github.com/alexpeattie/letsencrypt-fromscratch/blob/master/client.rb). I rewrote the client and this guide in May 2020 to bring it in-line with the latest (and theoretically finalized) [ACME V2 spec](https://tools.ietf.org/html/rfc8555).
 
 #### About the guide
 
-This guide assumes no particular knowledge of TLS/SSL, cryptography or [ACME](https://github.com/letsencrypt/acme-spec/) - a general understanding of programming, HTTP and REST APIs is probably needed. It would also be useful to have a vague idea of what [Public-key cryptography](https://en.wikipedia.org/wiki/Public-key_cryptography) is.
+This guide assumes no particular knowledge of TLS/SSL, cryptography or [ACME](https://tools.ietf.org/html/rfc8555) - a general understanding of programming, HTTP and REST APIs is probably needed. It would also be useful to have a vague idea of what [Public-key cryptography](https://en.wikipedia.org/wiki/Public-key_cryptography) is.
 
 Hopefully this guide is useful to anyone looking to build a Let's Encrypt client, or anyone looking to understand more about how LE/ACME works. Following the guide, you should be able to create a fully fledged LE client and issue a valid certificate in less than an hour. The guide does assume **you control a domain name**.
 
@@ -19,13 +19,17 @@ The guide and client code are all [MIT licensed](https://github.com/alexpeattie/
 
 #### Technology
 
-This example code is written in Ruby (I used 2.3), and is largely dependency free (apart from OpenSSL). We use [HTTParty](https://github.com/jnunemaker/httparty) for more convenient API requests - but you could use vanilla `Net::HTTP` if you're a masochist :see_no_evil:. And we'll use additional gems to upload files and provision DNS records.
+This example code is written in Ruby (I used 2.7.1), and is largely dependency free (apart from OpenSSL). We use [HTTParty](https://github.com/jnunemaker/httparty) for more convenient API requests - but you could use vanilla `Net::HTTP` if you're a masochist :see_no_evil:. And we'll use additional gems to upload files and provision DNS records.
 
 The choice of language is meant to be a background factor - the guide is (hopefully) illustrative & understandable even if you're not familiar with/interested in Ruby.
 
 #### Credits
 
-I heavily referenced Daniel Roesler's absolutely awesome [acme-tiny](https://github.com/diafygi/acme-tiny) and the [ACME spec](https://github.com/ietf-wg-acme/acme/) while writing this tutorial. I'd recommend checking out both as a supplement to this guide. Image credits at [the bottom](#image-credits).
+I heavily referenced Daniel Roesler's absolutely awesome [acme-tiny](https://github.com/diafygi/acme-tiny) and the [ACME spec](https://tools.ietf.org/html/rfc8555) while writing this tutorial. I'd recommend checking out both as a supplement to this guide. Image credits at [the bottom](#image-credits).
+
+#### V1 → V2 migration
+
+I've signposted any breaking (or notable) changes between V1 and V2 of the ACME spec/LE API with :warning:/:information_source: callouts. If you read the old version of this guide, you're migrating a V1 client to V2, or are particularly curious these callouts should be helpful. Otherwise, you can safely ignore them!
 
 ## Table of Contents
 
@@ -83,11 +87,17 @@ We'll **share our public key with Let's Encrypt** when we register, and sign all
 
 It's fine to use existing SSH keys, if you've already got them generated and they're long enough:
 
-```shell
+```bash
 openssl rsa -in ~/.ssh/id_rsa -text -noout | head -n 1
 ```
 
-If you see `Private-Key: (2048 bit)` or `Private-Key: (4096 bit)` you're good to go (if you're interested, there's more info about key size in [Appendix 5](#appendix-5-key-size)). Otherwise, we'll need to generate them - [Github has great instructions on how](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/). Let's begin by loading our key-pair into Ruby:
+If you see `Private-Key: (2048 bit)` or `Private-Key: (4096 bit)` you're good to go (if you're interested, there's more info about key size in [Appendix 5](#appendix-5-key-size)). Otherwise, we'll need to generate them:
+
+```bash
+ssh-keygen -m PEM -t rsa -b 4096
+```
+
+Let's begin by loading our key-pair into Ruby:
 
 ```ruby
 require 'openssl'
@@ -122,7 +132,7 @@ POST https://api.github.com/repos/alexpeattie/letsencrypt-fromscratch/issues
 The key difference with the Let's Encrypt API is we can't just send our JSON payload in a nice human-readable format as above, because we'll be signing it with our client private key to prove our identity. This is what a request to the Let's Encrypt API looks like:
 
 ```json
-POST https://acme-staging-v02.api.letsencrypt.org/acme/new-acct
+POST https://acme-v02.api.letsencrypt.org/directory/acme/new-acct
 
 {
   "payload": "eyJyZXNvdXJjZSI6Im5ldy1jZXJ0IiwiY3NyIjoiTUlJRVhEQ0NBa1FDQVFBd0Z6RVZNQk1HQTFVRUF3d01abWxzWlhNdWNHVm5MbU52TUlJQ0lqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FnOEFNSUlDQ2dLQ0FnRUE2ZG9JNWdlc1VWZVV2czJXN1h3LV9JcDg2eFl3ZnV0MDVNWE1aYWpWa3lMS1lhNHpjdGs3Y2hIN1ZuQWsxVF9uTXNaM0hYTlQ3X0J0R1hkYnlJR0FqRXhpR3F4cm5LejJqSS1JTVRNU1RKSklmRVhDUVJqUkx2U0c2S3VYbXk2aGhkS3BLMkpRam10OTh0QmxUY0NxbFFKNGRZWV9oMVFCTmYwZmUwN3p4T24zUXlaeU9Da05GMkdGQmZoSWZqTGRuVXJCbDBSejlTSUhLZkZTWW13SldKMTBBLWJiNVdRM2FkUWlNWF83amhYWHVBdUdDZnRBZ2h1UGdPWjlTalJXYVBpalNkOUxERWk1Y2pCalFsN1o4a0ZKTnV0VndSQlNFTDFIQVVNWE9ndkxKLW5mVjV4Tm15VHdmYTRsdXV4WEtsVnpJZFlmZDRUZWV1NHhwUTAxb29vQ0dLRUVCZ3VMQzdQLUtjemg4MUxXaTZtcExIRVZwOTNzWi1QZDZvNlROMFlabVZjaUwtNlJpTGRXY2hUeEtkbjNvTS1UYmRBTUVxb3VmTU5JYkh6LUVHREFxUkhGOUxCTU43bFlPcWJ0dWFmcjduN1EtVmQxN19KTGIxcnpONVFmclZvd2o4cUJpUHlRUndXbDhqN2hiLVpCR1NpMlJNb0V3LWNURG1KYjIweWUwQXZrWHhqVmxqbTN1aGpWVWRHTEtTQ0dfM1I4V0VuWEI3akRTV3Zpd0NEdDFKLWtPSW5EOEVUcjFvVDJKWWJ5N0FsaS12R25jdjJRdlhSb010RG9MN3F0MmkzSHNNZzhORjFDSHVhRUQ3RXdiTEMwRTRpWnZfcUw2WW45endqMVZ2bUZtbjA3T1ItanVOYkFnUXAtb01XR1lORDFKMnRpSW5QV0RtVUNBd0VBQWFBQU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQ0FRREdPdjUxc1hlUWNSLVhYMmUtbDZfSEt1WjNfVTdKbTJmNWtMMWJvbkpwOUM0UExacVNZMzNDZE5FbE1BcEVRczFzLTVhWEJCemRYWWE1X05hTFB2cm5fRm5mb2d1cnJHOXV6cU1vT0QtMjMtUnd5QkNLZFpNQ3gyVmd0YWNFU3RiZ2RLamNMRnRNRVE4YnR1NHIxMXVKQWlrblRIQnk4V3ZmaHREVS1Da0FkT2FYZV8zMktKSVV4Z05LSzhiYnRVUGlFc21jd3VqUGVzUkprWUh1QWVKc2JFQkY5ekVZNjlCazZiZVZKUUpxRjR4VjhYYmJheGZSX1N6TG5NWnJZNFhoNDNXbGRPN1UzZm9BZHYtLWk3eTlDbDUxaTJRV1RZMHFGcGVmd19nUU93SFFWMW9BRWJ0OWwyYkgyNGEtZ2NKUE9RNEhTdTBEV0ZHaFdSVkVuMUJsQ01XMkxGQnp2elpzMGdIaFhnQ1psVnNGcE1nYndJMThBLTA4UjZvS2FRWC1fM2tDb0FIaXcxQ1pdanaVQ1ZVOVRZNXNUMVlnZXBJVzBkT0VHYXY3YUJMXzNCbk9HVzVlMlZ2LXN5aGVSZS1ORzhXTEZiOHRyc2hMYTRPOVVjS3h3Nzl0MjFGaEhUYXhIblJLcDhFR3p3M2ZoZElMUW42YVlkb0k4Wm9faGJJaUE0cEhoMXlCbGpLU2Q3Zk1xTzkzX3JxV2Y4NzRfd2Q4N3RhcDFmb1pyZ1dYMVU5Wm9ZUnhFZ0FQOVN1cUdrcTJVUl9ucU9CQl9XaVBPM2ZGcFc3cTB6UEp1QUtBNWZIdDdFRG1HUldkTWNGXzM0SDdNenZPQk4tckI2S3VZTUtzWXpkS1ZEMDhwUnhUVVhKc3Nrb2t2MVF3aGNmNklzdEFtMDJ6bjhfWHBRIn0",
@@ -142,7 +152,7 @@ Don't worry, it's not really as intimidating as it looks. In this section we'll 
 Let's look at our request again, this time, I'll truncate the encoded data a bit for readability:
 
 ```json
-POST https://acme-staging-v02.api.letsencrypt.org/acme/new-acct
+POST https://acme-v02.api.letsencrypt.org/acme/new-acct
 
 {
   "payload": "eyJyZXNvdXJjZSI6Im5ldy1jZ...",
@@ -153,9 +163,11 @@ POST https://acme-staging-v02.api.letsencrypt.org/acme/new-acct
 
 Notice that we have three keys in the JSON we're `POST`ing to Let's Encrypt: `"payload"`, `"protected"` and `"signature"`. All requests we send to LE will contain only these keys, which each serve a distinct role.
 
-> :warning: V2 breaking change: Requests previously used to include an unprotected header (provided with the key `"header"`).
+> :warning: V2 breaking change: requests previously used to include an unprotected header (provided with the key `"header"`).
 
 **`"payload"`**, as the name, implies is where the 'meat' of the request goes. Remember our [Github example](#user-content-github-example), where we provided the title and body of the issue we were creating? This is the kind of that goes into payload. If we're registering an account, the payload will contain our registration details (email, name, contact details etc.). If we're ordering a certificate, the payload will contain the domain names we're looking to secure.
+
+> :warning: V2 breaking change: payload used to include the resource type with each request (e.g. `{"resource":"new-reg"}`); this is no longer the case in V2.
 
 **`"protected"`** is short for 'integrity-protected header'; this is where we include some important metadata. First we confirm the **URL** we're requesting and include a **nonce** (see part d) - this makes it difficult for an attacker to try and redirect or replay our requests. We also include details about our **public key** - either by sending the important parts of the key in a special format, or a unique ID for the key which LE keeps on file. LE will then use the public key to verify the...
 
@@ -336,7 +348,7 @@ Let's Encrypt provides us a nonce in the `Replay-Nonce` header of every request,
 
 Ruby comes with the `Net::HTTP` library built in for making HTTP requests, but it's a bit cumbersome. To make our life easier, we'll use [HTTParty](https://github.com/jnunemaker/httparty) - although this is by no means a necessity.
 
-```shell
+```bash
 gem install httparty
 ```
 
@@ -354,9 +366,11 @@ HTTParty::Basement.default_options.update(debug_output: $stdout)
 
 Now we're ready to make a request to the new nonce endpoint. Because we only need the headers, we can just make a `HEAD` request:
 
+> :information_source: V2 change: the new nonce endpoint is an addition in V2.
+
 ```ruby
 def nonce
-  HTTParty.head('https://acme-staging-v02.api.letsencrypt.org/acme/new-nonce')['Replay-Nonce']
+  HTTParty.head('https://acme-v02.api.letsencrypt.org/acme/new-nonce')['Replay-Nonce']
 end
 ```
 
@@ -421,7 +435,7 @@ def protected_header(url, kid = nil)
 end
 
 def nonce
-  HTTParty.head('https://acme-staging-v02.api.letsencrypt.org/acme/new-nonce')['Replay-Nonce']
+  HTTParty.head('https://acme-v02.api.letsencrypt.org/acme/new-nonce')['Replay-Nonce']
 end
 
 request = {
@@ -446,9 +460,9 @@ request[:signature] = client_key.sign(hash_algo, [ request[:protected], request[
 
 #### f. Making requests
 
-> :warning: V2 breaking change: the LE API requires the correct Content-Type in POST requests as of March 29th 2018.
+> :warning: V2 breaking change: the LE API requires the correct Content-Type in POST requests as of March 2018.
 
-Now we've built the request data just as Let's Encrypt wants, we have everything we need to start making requests. Per the ACME spec ([Section 6.2](https://tools.ietf.org/html/draft-ietf-acme-acme-10#section-6.2)):
+Now we've built the request data just as Let's Encrypt wants, we have everything we need to start making requests. Per the ACME spec ([Section 6.2](https://tools.ietf.org/html/rfc8555#section-6.2)):
 
 > Because client requests in ACME carry JWS objects in the Flattened JSON Serialization, they must have the "Content-Type" header field set to "application/jose+json"
 
@@ -458,7 +472,23 @@ So, our final request looks like this:
 HTTParty.post(some_api_endpoint, body: JSON.dump(request), headers: { 'Content-Type' => 'application/jose+json' })
 ```
 
-Let's put everything into a reusable method that can take an arbitrary URL and payload. (We'll move `client_key` and `hash_algo` into methods at the same time):
+> :warning: V2 breaking change: the requirement for the `Content-Type: application/jose+json` header is new in V2.
+
+Let's put everything into a reusable method that can take an arbitrary URL and payload. We'll make the default payload an empty string - we'll use this default whenever we simply want to read a resource (rather than creating/updating anything). Usually we'd use a `GET` request for this (this is actually how it used to work), but [since 2018](https://community.letsencrypt.org/t/acme-v2-scheduled-deprecation-of-unauthenticated-resource-gets/74380) the best practice securely sign every request, even when we're just reading resources. The ACME spec calls this the ["`POST`-as-`GET`" pattern](https://tools.ietf.org/html/rfc8555#section-6.3):
+
+```ruby
+def signed_request(url, payload: '', kid: nil)
+  request = {
+    payload: base64_le(payload),
+    protected: protected_header(url, kid)
+  }
+  request[:signature] = base64_le client_key.sign(hash_algo, [request[:protected], request[:payload]].join('.'))
+
+  HTTParty.post(url, body: JSON.dump(request), headers: { 'Content-Type' => 'application/jose+json' })
+end
+```
+
+Let's also move `client_key` and `hash_algo` into their own methods. Here's everything we have so far:
 
 ```ruby
 HTTParty::Basement.default_options.update(debug_output: $stdout)
@@ -506,10 +536,10 @@ def protected_header(url, kid = nil)
 end
 
 def nonce
-  HTTParty.head('https://acme-staging-v02.api.letsencrypt.org/acme/new-nonce')['Replay-Nonce']
+  HTTParty.head('https://acme-v02.api.letsencrypt.org/acme/new-nonce')['Replay-Nonce']
 end
 
-def signed_request(url, payload, kid = nil)
+def signed_request(url, payload: '', kid: nil)
   request = {
     payload: base64_le(payload),
     protected: protected_header(url, kid)
@@ -527,21 +557,25 @@ I mentioned above that we should avoid hard-coding the URLs our client uses - th
 
 ```json
 {
-  "keyChange": "https://acme-staging-v02.api.letsencrypt.org/acme/key-change",
+  "keyChange": "https://acme-v02.api.letsencrypt.org/acme/key-change",
   "meta": {
-    "termsOfService": "https://letsencrypt.org/documents/LE-SA-v1.2-November-15-2017.pdf"
+    "caaIdentities": [
+      "letsencrypt.org"
+    ],
+    "termsOfService": "https://letsencrypt.org/documents/LE-SA-v1.2-November-15-2017.pdf",
+    "website": "https://letsencrypt.org"
   },
-  "newAccount": "https://acme-staging-v02.api.letsencrypt.org/acme/new-acct",
-  "newNonce": "https://acme-staging-v02.api.letsencrypt.org/acme/new-nonce",
-  "newOrder": "https://acme-staging-v02.api.letsencrypt.org/acme/new-order",
-  "revokeCert": "https://acme-staging-v02.api.letsencrypt.org/acme/revoke-cert",
+  "newAccount": "https://acme-v02.api.letsencrypt.org/acme/new-acct",
+  "newNonce": "https://acme-v02.api.letsencrypt.org/acme/new-nonce",
+  "newOrder": "https://acme-v02.api.letsencrypt.org/acme/new-order",
+  "revokeCert": "https://acme-v02.api.letsencrypt.org/acme/revoke-cert",
   "z93cEwMHcG8": "https://community.letsencrypt.org/t/adding-random-entries-to-the-directory/33417"
 }
 ```
 
 > :warning: V2 breaking change: several endpoints have been renamed, and LE has switched from kebab-case to camelCase.
 
-(Note: unlike most of the API's endpoints, the directory is viewable without any kind of special signed request, you can just visit it [in your browser](https://acme-staging-v02.api.letsencrypt.org)).
+(Note: unlike most of the API's endpoints, the directory is viewable without any kind of special signed request, you can just visit it [in your browser](https://acme-v02.api.letsencrypt.org/directory)).
 
 The camel-cased keys in the JSON object indicate the action (`newAccount` for account registration, `newOrder` to order a certificate etc.), and the values are the URI we'll need to make a signed request to. Even though [Cool URIs don't change](https://www.w3.org/Provider/Style/URI), using the directory means we don't have to hard-code the endpoints - and so our client is more resilient to any changes Let's Encrypt might make (credit to [@kelunik](https://github.com/kelunik) for suggesting this).
 
@@ -549,14 +583,14 @@ To avoid making repeated requests to the directory, let's make an `endpoints` me
 
 ```ruby
 def endpoints
-  @endpoints ||= HTTParty.get('https://acme-staging-v02.api.letsencrypt.org/directory').to_h
+  @endpoints ||= HTTParty.get('https://acme-v02.api.letsencrypt.org/directory').to_h
 end
 ```
 
 I like to move the directory URI into a constant, to make it clear that this value shouldn't be changed at runtime:
 
 ```ruby
-DIRECTORY_URI = 'https://acme-staging-v02.api.letsencrypt.org/directory'.freeze
+DIRECTORY_URI = 'https://acme-v02.api.letsencrypt.org/directory'.freeze
 
 def endpoints
   @endpoints ||= HTTParty.get(DIRECTORY_URI).to_h
@@ -565,10 +599,15 @@ end
 def nonce
   HTTParty.head(endpoints['newNonce'])['Replay-Nonce']
 end
-
 ```
 
-The neat thing is that this `DIRECTORY_URI` is the only URI we need to hard-code; every other endpoint we can either pull from the directory, or from the `Location` headers of the API's responses.
+The neat thing is that this `DIRECTORY_URI` is the only URI we need to hard-code; every other endpoint we can either pull from the directory, or from the API's responses. Another nice side-effect is we can very easily switch from the production Let's Encrypt API (the default used in this guide) to the LE [staging environment](https://letsencrypt.org/docs/staging-environment/):
+
+```ruby
+DIRECTORY_URI = 'https://acme-staging-v02.api.letsencrypt.org/directory'.freeze
+```
+
+Certificates generated by the staging environment won't be trusted by browsers, but it does have much [more generous rate limits](https://letsencrypt.org/docs/staging-environment/#rate-limits) - so it can be handy when we're developing LE/ACME clients.
 
 <br>
 
@@ -576,7 +615,7 @@ The neat thing is that this `DIRECTORY_URI` is the only URI we need to hard-code
 
 OK, we've laid the foundations - let's make our first actual request to the Let's Encrypt API! The first step is to register our client public key with Let's Encrypt.
 
-First, we should ensure the user has read and accepted the Let's Encrypt [Terms of Service](https://letsencrypt.org/documents/LE-SA-v1.2-November-15-2017.pdf). We can skip this skip if we want to be naughty, but [per the ACME spec](https://tools.ietf.org/html/draft-ietf-acme-acme-09#section-7.3):
+First, we should ensure the user has read and accepted the Let's Encrypt [Terms of Service](https://letsencrypt.org/documents/LE-SA-v1.2-November-15-2017.pdf). We can skip this skip if we want to be naughty, but [per the ACME spec](https://tools.ietf.org/html/rfc8555#section-7.3):
 
 > Clients SHOULD NOT automatically agree to terms by default.  Rather, they SHOULD require some user interaction for agreement to terms.
 
@@ -594,7 +633,7 @@ end
 On to account creation! Since we're sending the public key with every request (in the `header` property of our JSON), we don't need to include much to register an account. In fact, we can register a valid account by just indicating that we accept the ToS:
 
 ```ruby
-new_registration = signed_request(endpoints['newAccount'], {
+new_registration = signed_request(endpoints['newAccount'], payload: {
   termsOfServiceAgreed: true
 })
 ```
@@ -608,7 +647,7 @@ We can optionally provide contact details (highly recommended), this will allow 
 > :warning: V2 breaking change: ACME used to support adding telephone numbers with the `tel:` prefix, this seems to have been removed.
 
 ```ruby
-new_registration = signed_request(endpoints['newAccount'], {
+new_registration = signed_request(endpoints['newAccount'], payload: {
   termsOfServiceAgreed: true,
   contact: ['mailto:me@alexpeattie.com']
 })
@@ -625,26 +664,25 @@ Sending the request should give us back a successful response:
 ```json
 -> "HTTP/1.1 201 Created\r\n"
 -> "Link: <https://letsencrypt.org/documents/LE-SA-v1.2-November-15-2017.pdf>;rel=\"terms-of-service\"\r\n"
--> "Location: https://acme-staging-v02.api.letsencrypt.org/acme/acct/5895484\r\n"
+-> "Location: https://acme-v02.api.letsencrypt.org/acme/acct/5895484\r\n"
 ...
 reading 919 bytes...
 {
-  "id": 5895484,
   "key": {
     "kty": "RSA",
     "n": "wHSRCVc0AI_G36MePdFotkyrTIgzgVuDXFValp7Vm-Qu0mVdS06h_Gjulrwj1TseXbE5Q90qIPSCaHKhV4jr0ahq6qRam2LsBh3HfQz8A3eZ5AoVOlBg7xwBbYgA2QVYlfqQbHmlfu_ZSxk6oCHjtGg3ld6VsC_FG67Ab08uGAlXQyGtsOolo7AOcduJqdCG-jgWeaw_g0FH8kmO0GhG88m7m3H3Cbe0GjQr8Mvz-T43axln87tY3u21IbfWpoEM87JHUJ9z_Csx26Hgi7BObkUjJqXK3LCV9dnAKuQqNA2ewWd35zMCdE95TZ03vB21GlAM3o4orTUQERoWcmcMxl8vghRjlp1vH6_btPDGaN-dVLQ_AE0eTXeIPbGCM4Tb7wJsWkv0qtw1xXXe8kVQeBKcaMQrI1zaW0EB1kp0_NP9NdLMZnYVtsOOrOHpj42d6rIsYyv3EmQwYHArpQJFs335SmCoTFjKTu0NMhjLU0P6ERay7VINPCjoEJXd5D7QtO1BLrq5A2kV0LNT9pxeQkoQctRS9M3mNFvhvf2qnM6d4AJpysmGnH95a8VLTOUaxY_EXudD3sfmM0uCPEB_C-jRCHO8CRhDIVX_rPW-muQ_wAqrbm73r9_Wd5kO-jKsbnBXbiXLjcR06bjioHn4DGkCoi5viW64TsEPxexpn48",
     "e": "AQAB"
   },
   "contact": [
-    "mailto:hello@example.com"
+    "mailto:me@alexpeattie.com"
   ],
   "initialIp": "123.456.744.89",
-  "createdAt": "2018-04-10T10:38:54.12898489Z",
+  "createdAt": "2020-05-09T16:47:29Z",
   "status": "valid"
 }
 ```
 
-The successful response basically just echoes back to us our registration details. We can see the exponent + modulus (`e` and `n`) values of our public key included at the top, as well as the unique `id` of our new account. Most important is our unique account URL in the `Location` header, in our case: `https://acme-staging-v02.api.letsencrypt.org/acme/acct/5895484`. This will serve as the identifier for our public key, so we won't need to send our exponent + modulus going forward. Let's save our `kid` for future requests:
+The successful response basically just echoes back to us our registration details. We can see the exponent + modulus (`e` and `n`) values of our public key included at the top, as well as the unique `id` of our new account. Most important is our unique account URL in the `Location` header, in our case: `https://acme-v02.api.letsencrypt.org/acme/acct/5895484`. This will serve as the identifier for our public key, so we won't need to send our exponent + modulus going forward. Let's save our `kid` for future requests:
 
 ```ruby
 kid = new_registration.headers['Location']
@@ -660,12 +698,12 @@ Note that LE verifies the domains of emails we provide (by checking their DNS `A
 }
 ```
 
-If we try and register the same key again we'll get an empty 200 (OK) response:
+(We'll also hit a 400 error if we try and use an `@example.com` address, so if you're using `client.rb` be sure to enter in proper contact details). If we try and register the same key again we'll get an empty 200 (OK) response:
 
 ```json
 -> "HTTP/1.1 200 OK"
 -> "Content-Type: application/problem+json"
--> "Location: https://acme-staging-v02.api.letsencrypt.org/acme/acct/5895484"
+-> "Location: https://acme-v02.api.letsencrypt.org/acme/acct/5895484"
 ...
 reading 0 bytes...
 -> ""
@@ -691,7 +729,7 @@ The next step is to inform Let's Encrypt which domain or subdomain we to provisi
 
 Challenges are how we prove a sufficient level of control over the identifier (domain name) in question. We can do this either by serving a specific response when LE hits a specific URL (which generally means uploading a file to our web-server), or by provisioning a DNS record. We'll need to use the latter type of challenge (DNS-based) if we want to issue a wildcard certificate.
 
-> :warning: V2 breaking change: Previous ACME versions provided challenges which leveraged the [Server Name Indication](https://tools.ietf.org/html/rfc6066#section-3) extension of TLS to serve a special self-signed certificate. These challenges have been [removed from the latest ACME spec](https://tools.ietf.org/html/draft-ietf-acme-acme-11#section-9.7.8) - partly due to a vulnerability affected TLS-SNI on shared hosting infrastructures (see [here](https://community.letsencrypt.org/t/2018-01-09-issue-with-tls-sni-01-and-shared-hosting-infrastructure/49996)). However, the challenge types remain reserved and might be brought back in the future.
+> :warning: V2 breaking change: previous ACME versions provided challenges which leveraged the [Server Name Indication](https://tools.ietf.org/html/rfc6066#section-3) extension of TLS to serve a special self-signed certificate. These challenges have been [removed from the finalized ACME spec](https://tools.ietf.org/html/rfc8555#section-9.7.8) - partly due to a vulnerability affected TLS-SNI on shared hosting infrastructures (see [here](https://community.letsencrypt.org/t/2018-01-09-issue-with-tls-sni-01-and-shared-hosting-infrastructure/49996)). `tls-sni-01` has now been superseded by `tls-alpn-01`, but that's beyond the scope of this guide.
 
 <br>
 
@@ -699,17 +737,17 @@ Challenges are how we prove a sufficient level of control over the identifier (d
 
 Asking LE to begin the process of certificate issuance is just a case of making another request to the LE API - this time to create a `newOrder`. 
 
-> :warning: V2 breaking change: We used to instead create an authorization directly. Now we create an order, and LE sends us a link to the authorization(s).
+> :warning: V2 breaking change: we used to instead create an authorization directly. Now we create an order, and LE sends us a link to the authorization(s).
 
 As you can probably guess, this means making a request to the `newOrder` endpoint. Beyond that just need tell LE what identifier (domain name) we want to authorize:
 
 ```ruby
-order = signed_request(endpoints['newOrder'], {
+order = signed_request(endpoints['newOrder'], payload: {
   identifiers: [{
     type: 'dns',
     value: domain
   }]
-}, kid)
+}, kid: kid)
 ```
 
 Note that for this `signed_request`, as we'll do for every request after registering, we provide the `kid` we saved earlier.
@@ -725,7 +763,7 @@ Assuming the domain we sent was properly formatted, Let's Encrypt should return 
 ```json
 {
   "status": "pending",
-  "expires": "2018-04-17T11:01:39.88615597Z",
+  "expires": "2020-05-16T16:47:30Z",
   "identifiers": [
     {
       "type": "dns",
@@ -733,20 +771,20 @@ Assuming the domain we sent was properly formatted, Let's Encrypt should return 
     }
   ],
   "authorizations": [
-    "https://acme-staging-v02.api.letsencrypt.org/acme/authz/KHeCk-lud6nXQAb7c-WQyIl_DORwsHaMCIaBp_C-w_E"
+    "https://acme-v02.api.letsencrypt.org/acme/authz-v3/4474222123"
   ],
-  "finalize": "https://acme-staging-v02.api.letsencrypt.org/acme/finalize/120651/340054"
+  "finalize": "https://acme-v02.api.letsencrypt.org/acme/finalize/85702020/3301243121"
 }
 ```
 
-Our order's been successfully created, but it's initial status is `"pending"` which means we haven't proven to LE that we control the domain; we're aiming to change it to `"valid"`. LE also sends us some important URLs: our `"authorizations"` (1 per the `"identifiers"` in the last step) - this is what we'll use to fetch our challenges shortly. The `"finalize"` URL will issue the certificate once our challenge is passed.
+Our order's been successfully created, but it's initial status is `"pending"` which means we haven't proven to LE that we control the domain; we're aiming to change it to `"ready"` (so we can request our certificate) and then ultimately `"valid"` (once our certificate has been issued). LE also sends us some important URLs: our `"authorizations"` (1 for each of the `"identifiers"` in the last step) - this is what we'll use to fetch our challenges shortly. The `"finalize"` URL will issue the certificate once our challenge is passed.
 
-Also notice that our order has an expiry date: 1 week after are order was placed. We need to validate our control of the requested the domain by then, otherwise this order will expire and we'll need to place a new one. The good new is that passing the challenge should only take a few minutes :innocent:.
+Also notice that our order has an expiry date: 1 week after are order was placed. We need to validate our control of the requested the domain by then, otherwise this order will expire and we'll need to place a new one. The good news is that passing the challenge should only take a few minutes :innocent:.
 
-Let's begin by looking at what's inside our `"authorizations"` URL:
+Let's begin by looking at what's inside our `"authorizations"` URL. :
 
 ```ruby
-HTTParty.get(order['authorizations'].first)
+signed_request(order['authorizations'].first, kid: kid)
 ```
 
 ```json
@@ -756,50 +794,62 @@ HTTParty.get(order['authorizations'].first)
     "value": "le.example.com"
   },
   "status": "pending",
-  "expires": "2018-04-17T11:01:39Z",
+  "expires": "2020-05-16T16:47:30Z",
   "challenges": [
-    {
-      "type": "dns-01",
-      "status": "pending",
-      "url": "https://acme-staging-v02.api.letsencrypt.org/acme/challenge/KHeCk-lud6nXQAb7c-WQyIl_DORwsHaMCIaBp_C-w_E/116525939",
-      "token": "rw76epX0FXz5XLIQEhAWsSjP_cXeXsVNJVdUjwntej8"
-    },
     {
       "type": "http-01",
       "status": "pending",
-      "url": "https://acme-staging-v02.api.letsencrypt.org/acme/challenge/KHeCk-lud6nXQAb7c-WQyIl_DORwsHaMCIaBp_C-w_E/116525940",
-      "token": "qDfPwOqgHfbEuggeq8XrPrBNFV11mgTRg6RNrcHSij4"
+      "url": "https://acme-v02.api.letsencrypt.org/acme/chall-v3/4490201234/DAPqRQ",
+      "token": "uUhfwl5Tlf6F7vb49akkOhSqli0dqiFv3a9rPi0afk39"
+    },
+    {
+      "type": "dns-01",
+      "status": "pending",
+      "url": "https://acme-v02.api.letsencrypt.org/acme/chall-v3/4490201234/rgEuWQ",
+      "token": "uUhfwl5Tlf6F7vb49akkOhSqli0dqiFv3a9rPi0afk39"
+    },
+    {
+      "type": "tls-alpn-01",
+      "status": "pending",
+      "url": "https://acme-v02.api.letsencrypt.org/acme/chall-v3/4490201234/fV9rgQ",
+      "token": "uUhfwl5Tlf6F7vb49akkOhSqli0dqiFv3a9rPi0afk39"
     }
   ]
 }
 ```
 
-We can see our `"identifier"` is echoed back to us, along with the authorization's `"status"` and `"expiry"` which matches that of our order. But we're really only interested in the `"challenges"`; we're provided with two distinct challenges corresponding with the two means we can convince LE we own the domain (crafting a specific HTTP response to a special endpoint for `http-01`, provisioning a special DNS record for `dns-01`).
+Notice this is the first time we're making a `GET`-like request (a `POST`-as-`GET` request, as explained above), where we don't include any payload.
 
-When we created our `newOrder` we mentioned we'd be given one authorization URL for each identifier we provided. In this example, we're only sending a single domain/identifier, but let's generalize our code to fetch the challenge data for every authorization URL, and then separate our HTTP and DNS challenges:
+We can see our `"identifier"` is echoed back to us, along with the authorization's `"status"` and `"expiry"` which matches that of our order. We're most only interested in the `"challenges"`; we're provided with three distinct challenges corresponding with the three means we can convince LE we own the domain:
+
+- Crafting a specific HTTP response to a special endpoint for `http-01`
+- Provisioning a special DNS record for `dns-01`
+- Offering a specified temporary certificate for `tns-alpn-01` (not covered in this guide)
+
+When we created our `newOrder` we mentioned we'd be given one authorization URL for each identifier we provided. For the main tutorial we'll only handle the client sending a single domain/identifier (hence `order['authorizations'].first`) - see [Appendix 4](http://localhost:8887/#appendix-4-multiple-subdomains) for how we can extend our client to handle multiple identifiers. Next, we'll pick out our HTTP and DNS challenges:
 
 ```ruby
-challenges = order['authorizations'].flat_map do |auth_url|
-  HTTParty.get(auth_url)['challenges']
-end
+challenges = signed_request(order['authorizations'].first, kid: kid)['challenges']
 
-http_challenge, dns_challenge = ['http-01', 'dns-01'].map do |challenge_type|
-  challenges.find { |challenge| challenge['type'] == challenge_type }
+http_challenges, dns_challenges = ['http-01', 'dns-01'].map do |challenge_type|
+  challenges.select { |challenge| challenge['type'] == challenge_type }
 end
 ```
 
-Each of our challenges have two key components:
+Each of our challenges has four components:
 
 ```json
 {
   "type": "http-01",
   "status": "pending",
-  "url": "https://acme-staging-v02.api.letsencrypt.org/acme/challenge/KHeCk-lud6nXQAb7c-WQyIl_DORwsHaMCIaBp_C-w_E/116525940",
-  "token": "qDfPwOqgHfbEuggeq8XrPrBNFV11mgTRg6RNrcHSij4"
+  "url": "https://acme-v02.api.letsencrypt.org/acme/chall-v3/4490201234/DAPqRQ",
+  "token": "uUhfwl5Tlf6F7vb49akkOhSqli0dqiFv3a9rPi0afk39"
 }
 ```
 
-The first is the `"uri"` of the challenge, which will allow us to notify LE that we're ready to take the challenge, on to check if we've passed. The second is the `"token"`: a unique, unguessable, random value sent to us by LE that we'll need to **incorporate into our challenge response** to prove we control the domain. Exactly how we'll incorporate our token depends on which kind of challenge we're taking....
+> :warning: V2 breaking change: `"url"` has been renamed from `"uri"` in V2.
+
+The `"type"` of the challenge is already familiar. The challenge's `"status"` will indicate ultimately indicate if we've passed the challenge (indicating we control the domain in question, and are thus eligible for a certificate). The `"url"` of the challenge will allow us to notify LE that we're ready to take the challenge, and to easily check if we've passed. Lastly, the `"token"` is a unique, unguessable, random value sent to us by LE that we'll need to **incorporate into our challenge response** to prove we control the domain. Exactly how we'll incorporate our token depends on which kind of challenge we're taking....
 
 <br>
 
@@ -809,9 +859,11 @@ Our first option is the `http-01` challenge. To pass this we need to ensure that
 
 `http://<< Domain >>/.well-known/acme-challenge/<< Challenge token >>`
 
-They receive a specific response (more on that below). Our domain is `le.alexpeattie.com`, `.well-known/acme-challenge/` is a fixed path [defined](https://tools.ietf.org/html/draft-ietf-acme-acme-01#section-7.2) by ACME, and our challenge token is `qDfPwOqgHfbEuggeq8XrPrBNFV11mgTRg6RNrcHSij4`, so the endpoint we'll need to serve the response from is:
+They receive a specific response (more on that below). Our domain is `le.alexpeattie.com`, `.well-known/acme-challenge/` is a fixed path [defined](https://tools.ietf.org/html/draft-ietf-acme-acme-01#section-7.2) by ACME, and our challenge token is `uUhfwl5Tlf6F7vb49akkOhSqli0dqiFv3a9rPi0afk39`, so the endpoint we'll need to serve the response from is:
 
-`http://le.alexpeattie.com/.well-known/acme-challenge/qDfPwOqgHfbEuggeq8XrPrBNFV11mgTRg6RNrcHSij4`
+`http://le.alexpeattie.com/.well-known/acme-challenge/uUhfwl5Tlf6F7vb49akkOhSqli0dqiFv3a9rPi0afk39`
+
+Since our challenge relies on a static URL which incorporates our domain exactly, the `http-01` challenge isn't suitable for issuing wildcard certificates - for that we'll have to use the the `dns-01` challenge (see below).
 
 ##### The key authorization
 
@@ -853,21 +905,21 @@ ssh root@162.243.201.152 'mkdir -p /usr/share/nginx/html/.well-known/acme-challe
 The code for uploading the challenge is quite straightforward:
 
 ```ruby
+require 'stringio'
 require 'net/scp'
 
-def upload(local_path, remote_path)
+def upload(file_contents, remote_path)
   server_ip = '162.243.201.152' # see Appendix 3
-  Net::SCP.upload!(server_ip, 'root', local_path, remote_path) 
+  Net::SCP.upload!(server_ip, 'root', StringIO.new(file_contents), remote_path)
 end
 
 # ..
 destination_dir = '/usr/share/nginx/html/.well-known/acme-challenge/'
 
-IO.write('challenge.tmp', http_challenge_response)
-upload('challenge.tmp', destination_dir + http_challenge['token']) and File.delete('challenge.tmp')
+upload(http_challenge_response, destination_dir + http_challenge['token'])
 ```
 
-Our simple nginx setup (see [Appendix 3]((#appendix-3-our-example-site-setup))) serves static files (if they exist) for any endpoint, so this should be all we need to ensure that a request to `http://le.alexpeattie.com/.well-known/acme-challenge/w2iwBwQq2ByOTEBm6oWtq5nNydu3Oe0tU_H24X-8J10` returns our key authorization as its response (we can [verify this](http://le.alexpeattie.com/.well-known/acme-challenge/w2iwBwQq2ByOTEBm6oWtq5nNydu3Oe0tU_H24X-8J10) in a browser).
+Our simple nginx setup (see [Appendix 3]((#appendix-3-our-example-site-setup))) serves static files (if they exist) for any endpoint, so this should be all we need to ensure that a request to `http://le.alexpeattie.com/.well-known/acme-challenge/w2iwBwQq2ByOTEBm6oWtq5nNydu3Oe0tU_H24X-8J10` returns our key authorization as its response (we could easily test this by going to the URL in a browser).
 
 <br>
 
@@ -878,12 +930,16 @@ The `dns-01` challenge was introduced at [the beginning of 2016](https://letsenc
 - We'll add a DNS [TXT record](https://en.wikipedia.org/wiki/TXT_record) rather than uploading a file
 - Rather than using "raw" key authorization as the record's contents, we'll use its (Base64 encoded) SHA-256 digest (see below)
 
-There are lots of ways to add the required DNS record - most DNS services provide a web interface (instructions for common providers [here](http://help.campaignmonitor.com/topic.aspx?t=100#dns-providers)) - we'll be programatically adding a record using the [DNSimple API](https://developer.dnsimple.com/v1/) & [associated gem](https://github.com/aetrion/dnsimple-ruby/tree/master-v1).
+There are lots of ways to add the required DNS record - most DNS services provide a web interface (instructions for common providers [here](http://help.campaignmonitor.com/topic.aspx?t=100#dns-providers)) - we'll be programatically adding a record using the [DNSimple API](https://developer.dnsimple.com/) & [associated gem](https://github.com/dnsimple/dnsimple-ruby).
 
-The key ingredients of a DNS record are its type, name and value/contents. The type of the record is `TXT`, which is designed for adding arbitrary text data to a DNS zone. The name of the record takes the format `_acme-challenge.subdomain.example.com`. The root domain name is appended to a record's name automatically, so we just need to provide the name as `_acme-challenge.subdomain` or just `_acme-challenge` if we're authorization the root domain.
+The key ingredients of a DNS record are its type, name and value/contents. The type of the record is `TXT`, which is designed for adding arbitrary text data to a DNS zone. The name of the record takes the format `_acme-challenge.subdomain.example.com`. The root domain name is appended to a record's name automatically, so we just need to provide the name as `_acme-challenge.subdomain` or just `_acme-challenge` if we're authorizing the root domain or issuing a wildcard certificate:
 
 ```ruby
+# to authorize le.alexpeattie.com
 record_name = '_acme-challenge.le'
+
+# to authorize alexpeattie.com or *.alexpeattie.com
+record_name = '_acme-challenge'
 ```
 
 To construct the contents of our record, we'll start by creating our "raw" challenge response in the same manner as in the `http-01` challenge:
@@ -900,25 +956,29 @@ dns_challenge_response = base64_le(hash_algo.digest raw_challenge_response)
 
 ##### Adding the record
 
-We'll use the [dnsimple-ruby gem](https://github.com/aetrion/dnsimple-ruby/tree/master-v1) to add our `TXT` record:
+We'll use the [dnsimple-ruby gem](https://github.com/aetrion/dnsimple-ruby) to add our `TXT` record:
 
-```shell
-gem install dnsimple -v 2.2
+```bash
+gem install dnsimple
 ```
 
-We'll also need to get our API token from the [DNSimple web interface](https://dnsimple.com/user). Then using the gem to add the TXT record, with the correct record name & content. We'll set a relatively low TTL (time to live) of 60 seconds, because we don't want our resolvers to cache the record for long - in case we need to redo the challenge, for example.
+We'll also need to get our API account token from the [DNSimple web interface](https://support.dnsimple.com/articles/api-access-token/). Then using the gem to add the TXT record, with the correct record name & content. We'll set a relatively low TTL (time to live) of 60 seconds, because we don't want our resolvers to cache the record for long - in case we need to redo the challenge, for example.
 
 ```ruby
 require 'dnsimple'
 
-dnsimple = Dnsimple::Client.new(username: ENV['DNSIMPLE_USERNAME'], api_token: ENV['DNSIMPLE_TOKEN'])
-challenge_record = dnsimple.domains.create_record('alexpeattie.com', {
+dnsimple = Dnsimple::Client.new(access_token: ENV['DNSIMPLE_ACCESS_TOKEN'])
+account_id = dnsimple.identity.whoami.data.account.id
+
+challenge_record = dnsimple.domains.create_record(account_id, 'alexpeattie.com', {
   record_type: 'TXT',
   name: record_name,
   content: dns_challenge_response,
   ttl: 60
 })
 ```
+
+(If you see a `NoMethodError (undefined method 'id' for nil:NilClass)` on the `account_id` line, you might be using a user token rather than an account token).
 
 Lastly, we'll use Ruby's [Resolv](http://ruby-doc.org/stdlib-2.3.0/libdoc/resolv/rdoc/Resolv.html) library (part of the std lib) to wait until the challenge record's been added:
 
@@ -935,26 +995,25 @@ end
 
 #### e. Telling LE we've completed the challenge
 
-To tell LE we've completed the challenge, we need to make a request to the challenge URI we got earlier (`https://acme-v01.api.letsencrypt.org/acme/challenge/-gPc-DOOMPAqlaNV2_NCbwieC7cDgmsDxS4d0Ounp8A/5157174` or `/5157175`).
+To tell LE we've completed the challenge, we need to make a request to the challenge URL we got earlier (`https://acme-v02.api.letsencrypt.org/acme/chall-v3/4490201234/DAPqRQ` or `https://acme-v02.api.letsencrypt.org/acme/chall-v3/4490201234/rgEuWQ`).
 
-Our request needs to include the field `keyAuthorization` with the key authorization we've just generated:
+It's fairly arbitrary what we ought to send to LE to indicate we're ready to have our challenged checked. Per the spec, we just send an empty JSON body (`{}`) as our payload:
 
 ```ruby
-signed_request(http_challenge['uri'], { # or dns_challenge['uri']
-  resource: 'challenge',
-  keyAuthorization: http_challenge_response # or dns_challenge_response,
-})
+signed_request(http_challenge['url'], payload: {}, kid: kid) # or dns_challenge['url']
 ```
+
+> :warning: V2 breaking change: previously we would send the key authorization to indicate our challenge was ready to be checked.
 
 <br>
 
 #### f. Wait for LE to acknowledge the challenge has been passed
 
-Finally it's just a case of polling the challenge URI we've been given and wait for its status to become `"valid"`. If it's still `"pending"` we'll `sleep` for 2 seconds then try again. Any other status means something's gone wrong :sob:.
+Finally it's just a case of polling the challenge URL we've been given and wait for its status to become `"valid"`. If it's still `"pending"` we'll `sleep` for 2 seconds then try again. Any other status means something's gone wrong :sob:.
 
 ```ruby
 loop do
-  challenge_result = HTTParty.get(challenge['uri'])  # or dns_challenge['uri']
+  challenge_result = signed_request(http_challenge['url'], kid: kid) # or dns_challenge['url']
 
   case challenge_result['status']
     when 'valid' then break
@@ -967,8 +1026,34 @@ end
 If we chose the DNS challenge, we should also clean up after ourselves by deleting the record (so our challenge attempt doesn't interfere with future challenge attempts, which will also require `TXT` records using the `_acme-challenge.le` name):
 
 ```ruby
-dnsimple.domains.delete_record('alexpeattie.com', challenge_record.id)
+dnsimple.zones.delete_zone_record(account_id, 'alexpeattie.com', challenge_record.data.id)
 ```
+
+As a final sanity check, let's re-request our original order. We should now see our order's status has changed to `"ready"`:
+
+```ruby
+order = signed_request(order.headers['Location'], kid: kid)
+raise("Unexpect order status (should be ready)") unless order['status'] == 'ready'
+```
+
+```json
+{
+  "status": "ready",
+  "expires": "2020-05-16T16:47:30Z",
+  "identifiers": [
+    {
+      "type": "dns",
+      "value": "le.alexpeattie.com"
+    }
+  ],
+  "authorizations": [
+    "https://acme-v02.api.letsencrypt.org/acme/authz-v3/4474222123"
+  ],
+  "finalize": "https://acme-v02.api.letsencrypt.org/acme/finalize/85702020/3301243121"
+}
+```
+
+Lastly, we can issue our certificate by sending a properly formed request to our order's `"finalize" endpoint.
 
 <br>
 
@@ -985,52 +1070,48 @@ IO.write('domain.key', domain_key.to_pem)
 
 **You might alternatively want to use a 2048 bit key (see [Appendix 5](#appendix-5-key-size) for more).*
 
-Ruby's `OpenSSL` module makes the [generation of the CSR](http://ruby-doc.org/stdlib-2.3.0/libdoc/openssl/rdoc/OpenSSL.html#module-OpenSSL-label-Certificate+Signing+Request) very straightforward:
+Next we turn to Ruby's `OpenSSL` module to [generate our CSR](http://ruby-doc.org/stdlib-2.3.0/libdoc/openssl/rdoc/OpenSSL.html#module-OpenSSL-label-Certificate+Signing+Request):
 
 ```ruby
 csr = OpenSSL::X509::Request.new
-csr.subject = OpenSSL::X509::Name.new([['CN', 'le.alexpeattie.com']])
 csr.public_key = domain_key.public_key
+
+alt_name = OpenSSL::X509::ExtensionFactory.new.create_extension("subjectAltName", "DNS: le.alexpeattie.com")
+extensions = OpenSSL::ASN1::Set([OpenSSL::ASN1::Sequence([alt_name])])
+csr.add_attribute OpenSSL::X509::Attribute.new('extReq', extensions)
+
 csr.sign domain_key, hash_algo
 ```
 
-We need to set the subject of the CSR - in this case the common name (domain name) we want to secure. Then we sign our certificate with our (private) `domain_key`.
+This snippet is admittedly a bit impenetrable. The key points are that we indicate the domain name (`"DNS: le.alexpeattie.com"`) then sign our CSR with our `domain_key`. We could also generate a CSR on the command line:
 
-LE needs us to send CSR in binary (.der) format - Base64 encoded of course. We'll be making a request for a `new-cert`:
+```
+openssl req -new -sha256 -subj "/CN=le.alexpeattie.com" -key domain.key -addext "subjectAltName = DNS:le.alexpeattie.com"
+```
+
+> :warning: V2 breaking change: in the previous version of this guide we indicated the domain with only a Common Name in our CSR's `Subject` field rather than using `subjectAltName`. This is now deprecated by browsers (Chrome 58 will [display a certificate error](https://www.entrustdatacard.com/knowledgebase/chrome-58-security-features#cn) for certificates that do this) and is no supported for LE certificate issuance.
+
+LE needs us to send CSR in binary (.der) format - Base64 encoded of course - to our order's `"finalize"` endpoint:
 
 ```ruby
-certificate_response = signed_request(endpoints['new-cert'], {
-  resource: 'new-cert',
+finalized_order = signed_request(order['finalize'], payload: {
   csr: base64_le(csr.to_der),
-})
+}, kid: kid)
 ```
 
-Let's Encrypt should respond with our brand new, DV certificate :tada: :tada:. It's not quite ready to use though.
+> :warning: V2 breaking change: previously, certificate issuance was done with a static "new certificate" endpoint, rather than the order's `"finalize"` URL
 
-#### Formatting tweaks
-
-Certificates should be typically enclosed by a `-----BEGIN CERTIFICATE-----` header and `-----END CERTIFICATE-----` (RFC [here](http://tools.ietf.org/html/rfc7468#section-2)) with each line wrapped at 64 characters. We could either do that manually (e.g. see [tiny-acme's](https://github.com/diafygi/acme-tiny/blob/master/acme_tiny.py) implementation) or let [`OpenSSL::X509::Certificate`](http://ruby-doc.org/stdlib-2.3.0/libdoc/openssl/rdoc/OpenSSL/X509/Certificate.html) take care of it:
+We're given back a updated instance of our original order with a new `"certificate"` key. This URL points to our ready-to-use certificates, including all the necessary [intermediate certificates](https://letsencrypt.org/certificates/) - all we need to do is download it (using one last `GET`-as-`POST` request):
 
 ```ruby
-certificate = OpenSSL::X509::Certificate.new(certificate_response.body)
+IO.write("certificate.pem", signed_request(finalized_order['certificate'], kid: kid).body)
 ```
 
-#### Adding intermediates
+> :information_source: V2 change: previously, we had to do much more work to get our certificate ready to use, manually coercing it into a valid PEM format and manually fetching the intermediate certificates. In V2, Let's Encrypt does all that for us and returns a valid `application/pem-certificate-chain` response.
 
-We also need to complete our trust chain, which means grabbing the Let's Encrypt cross-signed intermediate certificate (see <https://letsencrypt.org/certificates/>). Some browsers will resolve an incomplete trust chain, but it's something we want to avoid. There's much more info on why we need to complete this step and the difference between the different intermediates LE offers in [Appendix 2: The trust chain & intermediate certificates](#appendix-2-the-trust-chain--intermediate-certificates).
+That's it - we're done with our client and have our certificate (valid for the next 90 days) that will be accepted by all major browsers :white_check_mark:! Completed authorizations are valid for 30 days, so we can our renew certificate without needing to take a challenge during that period.
 
-Occasionally server software might want us to provide our intermediate certificates separately, but generally we'll bundle them together in a single file. Helpfully, LE provides a link to the latest intermediate certificate in the certificate response's `Link` header (it has the relation type `"up"`):
-
-```
-Link: </acme/issuer-cert>;rel="up"
-```
-
-```ruby
-intermediate = OpenSSL::X509::Certificate.new HTTParty.get(certificate_response.links.by_rel('up').target).body
-IO.write('chained.pem', [certificate.to_pem, intermediate.to_pem].join("\n"))
-```
-
-That's it - we're done with our client and have our certificate (valid for the next 90 days) that will be accepted by all major browsers :white_check_mark:! Completed authorizations are valid for 300 days, so we can our renew certificate without needing to take a challenge during that period.
+> :warning: V2 breaking change: completed authorizations used to be valid for much longer (300 days). And a word of caution even with the shortened 30 day grace period, as [Matt Nordhoff notes](https://community.letsencrypt.org/t/the-lifecycle-of-a-valid-authorization/101387/3) "an ACME client should always be prepared to validate again, rather than counting on authz reuse".
 
 This is the end of the main part of the guide, if you're interesting in the logistics of installing the certificate, keep reading...
 
@@ -1095,7 +1176,7 @@ ssl_ciphers "AES256+EECDH:AES256+EDH";
 
 Unless we're using an ECDSA certificate (see [Appendix 5](#appendix-5-key-size)) we should also generate a stronger DH parameter - nginx uses a 1024-bit prime which has been shown to be potentially vulnerable to state level adversaries (<https://weakdh.org>). Ideally our DH parameter shouldn't be smaller than our key size (i.e. 4096-bit or 2048-bit). We can generate a DH parameter like so:
 
-```shell
+```bash
 ssh root@162.243.201.152
 
 cd /etc/nginx
@@ -1209,13 +1290,11 @@ If it's still unclear, imagine Alice & Bob are having a birthday party. Guests w
 
 At the party, a guest would have to provide information so we could verify the chain of invites led back to Alice or Bob. In the same way, a certificate should provide information about the chain of certificates (called the trust chain) which lead back to a trusted root CA. 
 
-In the future Let's Encrypt hopes to have its own trusted root CA: [ISRG Root X1](https://letsencrypt.org/certificates/). Right now ISRG Root X1 isn't trusted by any browsers or operating systems - so IdenTrust is acting as their root CA instead. Let's Encrypt's intermediate CA is issued directly by Identrust's root CA (which is trusted by all major browsers/OSes) so our trust chain is only three links long:
+Let's Encrypt has it's own root CA: [ISRG Root X1](https://letsencrypt.org/certificates/), which is now [widely trusted](https://letsencrypt.org/2018/08/06/trusted-by-all-major-root-programs.html) by browsers and operating systems. Since trusted root certificates are so powerful, it's best practice to directly sign certificates with them sparingly - instead LE will use their root certificate to sign an "intermediate certificate", which will then sign certificates for end-users. So our chain looks like this:
 
-- Our certificate ← issued by Let's Encrypt CA ← 'issued' by Identrust CA
+- Our certificate ← issued by Let's Encrypt's intermediate CA ← issued by Let's Encrypt's root CA (trusted by our browser/OS)
 
-'Issued' is a bit of oversimplification here - in fact, Identrust just cross-signed LE's CA certificate, but it achieves the same end-result: trust in all major browsers/OSes.
-
-So our complete trust chain should include our certificate, the [certificate of Let's Encrypt's intermediate CA](https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem.txt) (Let’s Encrypt Authority X3), and optionally the Identrust CA's [trusted root certificate](https://raw.githubusercontent.com/EFForg/https-everywhere/master/cert-validity/mozilla/builtin-certs/DST_Root_CA_X3.crt). In reality there's no point making the client download the root certificate - it needs to already be in the trust store anywhere. As [RFC 2246](https://www.ietf.org/rfc/rfc2246.txt) says:
+So our complete trust chain should include our certificate, the [certificate of Let's Encrypt's intermediate CA](https://letsencrypt.org/certs/letsencryptauthorityx3.pem.txt) (Let’s Encrypt Authority X3), and optionally Let's Encrypt's [trusted root certificate](https://letsencrypt.org/certs/isrgrootx1.pem.txt). In reality there's no point making the client download the root certificate - it needs to already be in the trust store anywhere. As [RFC 2246](https://www.ietf.org/rfc/rfc2246.txt) says:
 
 > Because certificate validation requires that root keys be distributed independently, the self-signed certificate which specifies the root certificate authority may optionally be omitted from the chain, under the assumption that the remote end must already possess it in order to validate it in any case.
 
@@ -1229,7 +1308,7 @@ FF 44 | Chrome 48 | IE 11 | Safari 7.1 | iOS 8 (Safari) | Windows Phone 8.1 | An
 
 #### Missing certificate chain
 
-If we only provide our certificate without LE's intermediate certificate, we have a **broken chain of trust**. Most browsers can actually recover from this. LE certificates leverage *Authority Information Access* which embeds information about the trust chain even if we (system admins) forget to provide it.
+If we were only to provide our certificate without LE's intermediate certificate, we have a **broken chain of trust**. Most browsers can actually recover from this. LE certificates leverage *Authority Information Access* which embeds information about the trust chain even if we (system admins) forget to provide it.
 
 We shouldn't rely on this though, most mobile browsers don't support AIA - nor does Firefox (who have explicitly said they [won't be adding it](https://bugzilla.mozilla.org/show_bug.cgi?id=399324)).
 
@@ -1239,15 +1318,7 @@ FF 44 | Chrome 48 | IE 11 | Safari 7.1 | iOS 8 (Safari) | Windows Phone 8.1 | An
 --- | --- | --- | --- | --- | --- | ---
 :no_entry: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :no_entry: | :no_entry: | :no_entry:
 
-#### LE root certificate
-
-Let's Encrypt has it's own root certificate authority that's separate from Identrust, called ISRG Root X1. When this root CA is widely trusted, expect it to take Identrust's place in the trust chain. We can already use an [intermediate certificate issued by ISRG Root X1](https://letsencrypt.org/certs/letsencryptauthorityx1.pem.txt) - the problem is that, at the time of writing, ISRG Root X1 isn't trusted anywhere (to my knowledge).
-
-If we try using the LE root-signed intermediate now, most browsers that support AIA will fallback to the valid trust chain, except desktop Safari.
-
-FF 44 | Chrome 48 | IE 11 | Safari 7.1 | iOS 8 (Safari) | Windows Phone 8.1 | Android 6
---- | --- | --- | --- | --- | --- | ---
-:no_entry: | :white_check_mark: | :white_check_mark: | :no_entry: | :no_entry: | :no_entry: | :no_entry:
+As of V2, Let's Encrypt already issues us with a complete certificate chain - so we'd actually have to make an effort to omit the neccessary intermediate certificate.
 
 <br>
 
@@ -1279,7 +1350,7 @@ Once our machine has been provisioned, take a note of the public IP, in this cas
 
 Using the IP, we'll SSH into our new box and install [nginx](http://nginx.org/):
 
-```shell
+```bash
 ssh root@162.243.201.152
 
 add-apt-repository ppa:nginx/stable
@@ -1308,7 +1379,7 @@ http {
 
 Lastly we'll restart nginx:
 
-```shell
+```bash
 sudo service nginx restart
 ```
 
@@ -1345,20 +1416,20 @@ A common use-case is having a single certificate cover the naked domain and `www
 ```ruby
 domains = %w(example.com www.example.com)
 
-domains.each do |domain|
-  auth = signed_request(endpoints['new-authz'], {
-    resource: 'new-authz',
-    identifier: {
-      type: 'dns',
-      value: domain
-    }
-  })
+order = signed_request(endpoints['newOrder'], payload: {
+  identifiers: domains.map { |domain| {
+    type: 'dns',
+    value: domain
+  } }
+}, kid: kid)
 
+domains.zip(order['authorizations']).each do |domain, auth|
+  challenges = signed_request(auth, kid: kid)['challenges']
   #.. rest of challenge passing code
 end
 ```
 
-Once we've authorized all the subdomains we want to include in the certificate, we can modify our CSR to use the SAN extension (warning: not the prettiest or most readable code you'll ever see):
+Once we've authorized all the subdomains we want to include in the certificate, we pass a comma seperated list of of DNS identifiers for our CSR's `subjectAltName`:
 
 ```ruby
 alt_names = domains.map { |domain| "DNS:#{domain}" }.join(', ')
@@ -1372,9 +1443,9 @@ csr.add_attribute OpenSSL::X509::Attribute.new(
 )
 ```
 
-That's all you need to get certificates to cover multiple host names, you can find the full code of the example in [`multiple_subdomains.rb`](https://github.com/alexpeattie/letsencrypt-fromscratch/blob/master/multiple_subdomains.rb).
+That's all you need to get certificates to cover multiple host names. You can find the full code of the example in [`multiple_subdomains.rb`](https://github.com/alexpeattie/letsencrypt-fromscratch/blob/master/multiple_subdomains.rb).
 
-**If you're running a site that, say, assigns thousands of subdomains to end users, you may be out of luck since "you can [only] issue certificates containing up to 2,000 unique subdomains per week" ([source](https://letsencrypt.org/docs/rate-limits/)). The only current work-around is to get your domain added to [Public Suffix list](https://publicsuffix.org/) - which LE treats as a [special case](https://github.com/letsencrypt/boulder/issues/1374). Additionally, wildcard certificates will [launch in January 2018](https://letsencrypt.org/2017/07/06/wildcard-certificates-coming-jan-2018.html).*
+**If you're running a site that, say, assigns thousands of subdomains to end users, you may be out of luck since "you can [only] issue certificates containing up to 2,000 unique subdomains per week" ([source](https://letsencrypt.org/docs/rate-limits/)). The only current work-around is to get your domain added to [Public Suffix list](https://publicsuffix.org/) - which LE treats as a [special case](https://github.com/letsencrypt/boulder/issues/1374). You'll need to issue a wildcard certificate instead.*
 
 <br>
 
@@ -1386,7 +1457,7 @@ Broadly-speaking key size means how hard a key is to crack. Longer keys offer mo
 
 We don't have a very broad choice when it comes to choosing key size. 2048 bits has effectively been an [enforced minimum](https://www.cabforum.org/wp-content/uploads/Baseline_Requirements_V1.pdf) since the beginning of 2014; 4096 bits is the upper bound. 4096 bits is favored by some, but is far from the standard right now. It's anticipated that 2048-bit keys will be considered secure [until about 2030](http://www.keylength.com/en/4/).
 
-2048 is the default key size for [cerbot](https://github.com/certbot/certbot#current-features). But you will need a 4096 bit key to score perfectly on the Key [SSL Labs' test](https://www.ssllabs.com/downloads/SSL_Server_Rating_Guide.pdf), and there are lively discussions advocating the LE default be raised to [4096](https://github.com/certbot/certbot/issues/489) or [3072](https://github.com/certbot/certbot/issues/2080). CertSimple did an [awesome, detailed rundown](https://certsimple.com/blog/measuring-ssl-rsa-keys) of the benefits of different key sizes, and basically concluded "it depends".
+2048 is the default key size for [certbot](https://github.com/certbot/certbot#current-features). But you will need a 4096 bit key to score perfectly on the Key [SSL Labs' test](https://www.ssllabs.com/downloads/SSL_Server_Rating_Guide.pdf), and there are lively discussions advocating the LE default be raised to [4096](https://github.com/certbot/certbot/issues/489) or [3072](https://github.com/certbot/certbot/issues/2080). CertSimple did an [awesome, detailed rundown](https://certsimple.com/blog/measuring-ssl-rsa-keys) of the benefits of different key sizes, and basically concluded "it depends".
 
 We will need a key size of 4096 bits to get a perfect SSL Labs score. Not all cloud providers support key sizes above 2048 bits though, AWS CloudFront being a notable example. If you want or need to use a 2048-bit key, you can specify the key length like so:
 
@@ -1398,18 +1469,15 @@ domain_key = OpenSSL::PKey::RSA.new(2048)
 
 If you really care about picking a good key, you might not want to use RSA at all. ECDSA ([Elliptic Curve Digital Signature Algorithm](https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm)) which gives a much better size vs. security trade-off. A 384 bit ECDSA is considered equivalent to a [7680 bit RSA key](http://crypto.stackexchange.com/questions/2482/how-strong-is-the-ecdsa-algorithm), and will also give a perfect SSL Labs score. More importantly, a number recently discovered SSL vulnerabilities (DROWN, Logjam, FREAK) target RSA-specific vulnerabilities which are not present in ECDSA certificates.
 
-We'll have to a bit more work to create an ECDSA CSR (see [this blog post I wrote](https://alexpeattie.com/blog/signing-a-csr-with-ecdsa-in-ruby) for a more detailed explanation):
+Creating an ECDSA CSR is mechanically almost identical to using an RSA key - we just need to set `csr.public_key` to `domain_key`, rather than `domain_key.public_key`:
 
 ```ruby
-# monkey patch to fix https://redmine.ruby-lang.org/issues/5600
-OpenSSL::PKey::EC.send(:alias_method, :private?, :private_key?)
-
 domain_key = OpenSSL::PKey::EC.new('secp384r1').generate_key
 IO.write('domain.key', domain_key.to_pem)
 
 csr = OpenSSL::X509::Request.new
 csr.subject = OpenSSL::X509::Name.new(['CN', 'le.alexpeattie.com'])
-csr.public_key = OpenSSL::PKey::EC.new(domain_key)
+csr.public_key = domain_key
 csr.sign domain_key, OpenSSL::Digest::SHA256.new
 ```
 
@@ -1441,11 +1509,9 @@ As well as support ECDSA-based certificates (see above), since 2016 Let's Encryp
 First, we'll need an EC keypair:
 
 ```bash
-openssl ecparam -genkey -name secp256k1 -noout -out ec-private.pem
+openssl ecparam -genkey -name prime256v1 -noout -out ec-private.pem
 openssl ec -in ec-private.pem -pubout -out ec-public.pem
 ```
-
-(Alternatively you can grab an Boulder's test EC key [here](https://github.com/letsencrypt/boulder/blob/f21a7e5ad2078563a7084f7cf0ebe80c9c0bc92b/test/ct-key.pem)
 
 Then, we'll need to change our `client_key` method to load our EC private key. 
 
@@ -1457,17 +1523,25 @@ Simple enough so far, unfortunately, things begin to get a bit complicated. For 
 
 With EC keys though, we'll use a different hashing algorithm depending on the curve used/key length (different curves = different key lengths):
 
-| Algorithm     | Curve name    | Key length (bits) | Hashing algorithm  |
-| ------------- | ------------- | ----------------- | ------------------ |
-| ES256         | P-256         | 256               | SHA-256            |
-| ES384         | P-384         | 384               | SHA-384            |
-| ES512         | P-521         | 521               | SHA-512            |
+| Algorithm | Curve name (JWK) | Curve name (OpenSSL)          | Key length (bits) | Hashing algorithm |
+|-----------|------------------|-------------------------------|-------------------|-------------------|
+| ES256     | P-256            | `prime256v1` (or `secp256r1`) | 256               | SHA-256           |
+| ES384     | P-384            | `secp384r1`                   | 384               | SHA-384           |
+| ES512     | P-521            | `secp521r1`                   | 521               | SHA-512           |
+
+Note that all the `ES*` use the standard ["NIST curves"](https://csrc.nist.gov/Projects/elliptic-curve-cryptography). Some people are suspicious that the NIST curves, particularly P-256 (more commonly known outside of a JWK context as `secp256r1`), could be vulnerable to state-level attackers (due to a [hypothesised backdoor](https://miracl.com/blog/backdoors-in-nist-elliptic-curves/)). Some crypto implementations (notably Bitcoin) prefer an alternative curve to `secp256r1` called `secp256k1`. However, this isn't supported by JWK, so generating a key like this:
+
+```bash
+openssl ecparam -genkey -name secp256k1 -noout -out ec-private.pem
+```
+
+will ultimately lead to a "Parse error reading JWS" error from Let's Encrypt. There is a [draft proposal](http://self-issued.info/docs/draft-jones-cose-additional-algorithms-00.html#rfc.section.3) to add a new "P-256k" curve to the JWK standard - but until that's adopted, stick to ES512 if you're worried.
 
 Eagle-eyed readers might spot something odd about the ES512: we have a key 521 bits long, but the associated digest size is 512 bits. It's not a typo, and it does make things a bit more awkward; we can't assume that key size = digest size. We can get the key's bit length/curve using `client_key.group.degree`, so let's write a method to get the associated digest size:
 
 ```ruby
 def digest_size
-  { 256: 256, 384: 384, 521: 512 }[client_key.group.degree]
+  { 256 => 256, 384 => 384, 521 => 512 }[client_key.group.degree]
 end
 ```
 
@@ -1479,16 +1553,26 @@ def hash_algo
 end
 ```
 
-Next, we need to modify our `header`. We'll ditching be ditching our `"e"` and `"n"` keys (they're specific to RSA keys), and we'll need to add a `"crv"` key to indicate the EC key's curve name. As we can see from the table above, for the curves we're concerned with, it's just the key's bit length prefixed with `"P-"`. Lastly, `alg` is now `"ES"` + `digest_size`, and `kty` (key type) is `"EC"`:
+Next, we need to modify our `protected_header` and `jwk` methods. In the former, we need to change our `alg` value to `"ES"` + `digest_size` (e.g. `"ES256"`):
 
 ```ruby
-@header ||= {
-  alg: "ES#{ digest_size }",
-  jwk: {
-    crv: "P-#{ client_key.group.degree }",
-    kty: 'EC'
-  }
-}
+def protected_header(url, kid = nil)
+  metadata = { alg: "ES#{ client_key.group.degree }", nonce: nonce, url: url }
+  #...
+```
+
+In `jwk` we'll ditching be ditching our `"e"` and `"n"` keys (they're specific to RSA keys), and we'll need to add a `"crv"` key to indicate the EC key's curve name. As we can see from the table above, for the curves we're concerned with, it's just the key's bit length prefixed with `"P-"`. `kty` (key type) is simply `"EC"`:
+
+```ruby
+
+def jwk
+  @jwk ||= begin
+    {
+      crv: "P-#{ client_key.group.degree }",
+      kty: 'EC'
+    }
+  end
+end
 ```
 
 Before we go any further, let's add a helper method which splits a string into pieces of a certain length (this will come in handy later):
@@ -1552,7 +1636,7 @@ x, y = split_into_pieces(coords_binary_data, piece_size: coords_binary_data.size
 Lastly, we'll need to Base64 encode our `x` and `y` values before sending them over the wire:
 
 ```ruby
-jwk: {
+{
   crv: "P-#{ client_key.group.degree }",
   x: base64_le(x),
   kty: 'EC',
@@ -1560,11 +1644,11 @@ jwk: {
 }
 ```
 
-To recap, our `header` method now looks like this:
+To recap, our `jwk` method now looks like this:
 
 ```ruby
-def header
-  @header ||= begin
+def jwk
+  @jwk ||= begin
     pub_key_hex = client_key.public_key.to_bn.to_s(16)
     pub_key_octets = split_into_pieces(pub_key_hex, piece_size: 2)
 
@@ -1573,25 +1657,22 @@ def header
     x, y = split_into_pieces(coords_binary_data, piece_size: coords_binary_data.length / 2)
 
     {
-      alg: "ES#{ digest_size }",
-      jwk: {
-        crv: "P-#{ client_key.group.degree }",
-        x: base64_le(x),
-        kty: 'EC',
-        y: base64_le(y)
-      }
+      crv: "P-#{ client_key.group.degree }",
+      kty: 'EC',
+      x: base64_le(x),
+      y: base64_le(y)
     }
   end
 end
 ```
 
-Worn out yet :sweat_smile:? There's one last step: we have to update how our signature is generated. When we sign a value using RSA, the signature is a single value `σ`, which is really just one long integer (see [Digital signature](https://en.wikipedia.org/wiki/Digital_signature#How_they_work) on Wikipedia). But DSA (which we use with EC keys) returns *a pair* of integers, typically denoted `r` and `s` (see Wikipedia's [DSA](https://en.wikipedia.org/wiki/Digital_Signature_Algorithm#Signing) article), so we'll need to make a few modifications to allow for this. First, `OpenSSL::PKey::EC` equivalent method to `#sign` is `#dsa_sign_asn1`:
+Worn out yet :sweat_smile:? There's one last step: we have to update how our signature is generated. When we sign a value using RSA, the signature is a single value `σ`, which is really just one long integer (see [Digital signature](https://en.wikipedia.org/wiki/Digital_signature#How_they_work) on Wikipedia). But DSA (which we use with EC keys) returns *a pair* of integers, typically denoted `r` and `s` (see Wikipedia's [DSA](https://en.wikipedia.org/wiki/Digital_Signature_Algorithm#Signing) article), so we'll need to make a few modifications to allow for this. We sign as normal:
 
 ```ruby
-signature = client_key.dsa_sign_asn1 hash_algo.digest([request[:protected], request[:payload]].join('.'))
+signature = client_key.sign(hash_algo, [request[:protected], request[:payload]].join('.'))
 ```
 
-Then we need to extract the value of (`r`, `s`) as binary strings. The signature is ASN.1 encoded, so we'll first decode it and convert it to an array (of two elements, i.e. `r` and `s`):
+But from this signature we need to extract the value of (`r`, `s`) as binary strings. The signature is ASN.1 encoded, so we'll first decode it and convert it to an array (of two elements, i.e. `r` and `s`):
 
 ```ruby
 decoded_signature = OpenSSL::ASN1.decode(signature).to_a
@@ -1614,7 +1695,7 @@ All the changes we needed to make are collected below (also see [`ec_client.rb`]
 ```ruby
 def client_key
   @client_key ||= begin
-    client_key_path = File.expand_path('~/Desktop/ec-private.pem')
+    client_key_path = File.expand_path('./ec-private.pem')
     OpenSSL::PKey::EC.new IO.read(client_key_path)
   end
 end
@@ -1623,47 +1704,56 @@ def split_into_pieces(str, opts = {})
   str.chars.each_slice(opts[:piece_size]).map(&:join)
 end
 
-def header
-  @header ||= begin
-    combined_coordinates = client_key.public_key.to_bn.to_s(16)
-    coord_octets = split_into_pieces(combined_coordinates, piece_size: 2)
+def jwk
+  @jwk ||= begin
+    pub_key_hex = client_key.public_key.to_bn.to_s(16)
+    pub_key_octets = split_into_pieces(pub_key_hex, piece_size: 2)
 
-    coord_octets.shift # drop the first octet (which just indicates key is uncompressed)
-    coords_bin = coord_octets.map(&:hex).pack('c*')
-    x, y = split_into_pieces(coords_bin, piece_size: coords_bin.length / 2)
+    pub_key_octets.shift # drop the first octet (which just indicates key is uncompressed)
+    coords_binary_data = pub_key_octets.map(&:hex).pack('c*')
+    x, y = split_into_pieces(coords_binary_data, piece_size: coords_binary_data.length / 2)
 
     {
-      alg: "ES#{ client_key.group.degree }",
-      jwk: {
-        crv: "P-#{ client_key.group.degree }",
-        x: base64_le(x),
-        kty: 'EC',
-        y: base64_le(y)
-      }
+      crv: "P-#{ client_key.group.degree }",
+      kty: 'EC',
+      x: base64_le(x),
+      y: base64_le(y)
     }
   end
 end
 
-def hash_algo
-  bit_size = client_key.group.degree
-  bit_size = 512 if bit_size == 521
-
-  OpenSSL::Digest.const_get("SHA#{bit_size}").new
+def digest_size
+  { 256 => 256, 384 => 384, 521 => 512 }[client_key.group.degree]
 end
 
-def signed_request(url, payload)
+def hash_algo
+  OpenSSL::Digest.const_get("SHA#{digest_size}").new
+end
+
+def protected_header(url, kid = nil)
+  metadata = { alg: "ES#{ client_key.group.degree }", nonce: nonce, url: url }
+
+  if kid
+    metadata.merge!({ kid: kid })
+  else
+    metadata.merge!({ jwk: jwk })
+  end
+
+  return base64_le(metadata)
+end
+
+def signed_request(url, payload: '', kid: nil)
   request = {
     payload: base64_le(payload),
-    header: header,
-    protected: base64_le(header.merge(nonce: nonce))
+    protected: protected_header(url, kid)
   }
-  signature = client_key.dsa_sign_asn1 hash_algo.digest([request[:protected], request[:payload]].join('.'))
+  signature = client_key.sign(hash_algo, [request[:protected], request[:payload]].join('.'))
   decoded_signature = OpenSSL::ASN1.decode(signature).to_a
 
   r, s = decoded_signature.map { |v| v.value.to_s(2) }
 
   request[:signature]  = base64_le(r + s)
-  HTTParty.post(url, body: JSON.dump(request))
+  HTTParty.post(url, body: JSON.dump(request), headers: { 'Content-Type' => 'application/jose+json' })
 end
 ```
 
@@ -1686,7 +1776,7 @@ Accordingly, most commercial providers offer certificates with 1, 2 or 3 year va
 
 *(Source: [Pros and cons of 90-day certificate lifetimes](https://community.letsencrypt.org/t/pros-and-cons-of-90-day-certificate-lifetimes/4621))*
 
-Let's Encrypt will send email reminders to the address(es) provided in the `contacts` field of your `new-reg` payload, at the following times:
+Let's Encrypt will send email reminders to the address(es) provided in the `contacts` field of your `newAccount` payload, at the following times:
 
 - 20 days before the date of expiry
 - 10 days before the date of expiry
@@ -1712,18 +1802,40 @@ OpenSSL::PKey::RSA.new IO.read(client_key_path)
 For our payload, we'll need the certificate in question. Since we have our private key locally, we'll assume the certificate is locally available too (though see [Scenario 2](#scenario-2-you-dont-have-access-to-the-private-key-for-the-certificate-but-you-still-have-access-to-the-client-key-for-the-account-which-issued-the-certificate) for alternative approaches):
 
 ```ruby
-cert_path = File.expand_path('~/Desktop/chained.pem')
-certificate = OpenSSL::X509::Certificate.new IO.read(cert_path)
+cert_path = File.expand_path('~/Desktop/certificate.pem')
+
+# Code for loading a chained certificate taken from https://github.com/ruby/openssl/issues/288
+CERTIFICATE_PATTERN = /-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----/m
+
+certificate_chain = IO.read(cert_path).scan(CERTIFICATE_PATTERN).map { |cert| OpenSSL::X509::Certificate.new(cert) }
+
+# The leaf certificate is first in the chain
+certificate = certificate_chain.first
 ```
 
-To revoke our certificate, we'll need to send a Base64 encoded version of the certificate in DER format:
+To revoke our certificate, we'll need to send a Base64 encoded version of the certificate in DER format, optionally along with an integer indicating the reason for the revocation:
 
 ```ruby
-new_registration = signed_request(endpoints['new-reg'], {
-  resource: 'revoke-cert',
-  certificate: base64_le(certificate.to_der)
+new_registration = signed_request(endpoints['revokeCert'], {
+  certificate: base64_le(certificate.to_der),
+  reason: 1
 })
 ```
+
+Reason codes are defined in [RFC 5280](https://tools.ietf.org/html/rfc5280#section-5.3.1) although only a subset are valid for use with LE, as summarized below:
+
+| Code | Reason                 | Valid for LE?      |
+|------|------------------------|--------------------|
+| 0    | Unspecified            | :white_check_mark: |
+| 1    | Key compromise         | :white_check_mark: |
+| 2    | CA compromise          | :no_entry:         |
+| 3    | Affiliation changed    | :white_check_mark: |
+| 4    | Superseded             | :white_check_mark: |
+| 5    | Cessation of operation | :white_check_mark: |
+| 6    | Certificate hold       | :no_entry:         |
+| 8    | Privilege withdrawn    | :no_entry:         |
+| 9    | Remove from CRL        | :no_entry:         |
+| 10   | AA compromise          | :no_entry:         |
 
 #### Scenario 2: You don't have access to the private key for the certificate, but you still have access to the client key for the account which issued the certificate
 
@@ -1734,13 +1846,13 @@ client_key_path = File.expand_path('~/.ssh/id_rsa')
 
 # ...
 
-new_registration = signed_request(endpoints['new-reg'], {
-  resource: 'revoke-cert',
-  certificate: base64_le(certificate.to_der)
+new_registration = signed_request(endpoints['revokeCert'], {
+  certificate: base64_le(certificate.to_der),
+  reason: 1
 })
 ```
 
-Note that you still need to provide the certificate in DER format, even if you're not providing the certificate's corresponding private key. You can dynamically fetch the certificate like so:
+Note that you still need to provide the certificate in DER format, even if you're not providing the certificate's corresponding private key. You can always fetch the certificate programatically like so:
 
 ```ruby
 uri, certificate = URI.parse("https://example.com"), nil

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ _t�
                 �%Ê�k��
 ```
 
-To avoid dealing with non-ASCII characters we'll need to [Base64 encode](https://en.wikipedia.org/wiki/Base64) most of our data. The good news is Ruby comes with Base64 handling as [part of the standard library](http://ruby-doc.org/stdlib-2.3.0/libdoc/base64/rdoc/Base64.html):
+To avoid dealing with non-ASCII characters we'll need to [Base64 encode](https://en.wikipedia.org/wiki/Base64) most of our data. The good news is Ruby comes with Base64 handling as [part of the standard library](https://ruby-doc.org/stdlib-2.7.1/libdoc/base64/rdoc/Base64.html):
 
 ```ruby
 Base64.urlsafe_encode64('test')
@@ -224,7 +224,7 @@ base64_le '{"contact":["mailto:me@alexpeattie.com"]}'
  #=> "eyJjb250YWN0IjpbIm1haWx0bzptZUBhbGV4cGVhdHRpZS5jb20iXX0"
  ```
 
-This a totally valid payload that we can send to Let's Encrypt. Obviously it'll be more convenient not to have to construct JSON strings by hand - so let's load in the [JSON library](http://ruby-doc.org/stdlib-2.3.0/libdoc/json/rdoc/JSON.html) (again part of the Ruby standard lib):
+This a totally valid payload that we can send to Let's Encrypt. Obviously it'll be more convenient not to have to construct JSON strings by hand - so let's load in the [JSON library](http://ruby-doc.org/stdlib-2.7.1/libdoc/json/rdoc/JSON.html) (again part of the Ruby standard lib):
 
 ```ruby
 require 'json'
@@ -270,7 +270,7 @@ Our choice of signing algorithm is one half of what LE will need to verify our s
 
 > :warning: V2 breaking change: the use of `kid` is one of the major departures from ACME V1. In V1 we'd send our JWK with each request, and `kid` didn't exist.
 
-Let's start with sending our public key as a JWK (which we'll do during account creation). The parts of the key we're interested in are the public key exponent (e) and the modulus (n). Helpfully our `client_key` has corresponding methods (`client_key.e` and `client_key.n`) - the only additionally steps we need to take are converting them to binary strings with `to_s(2)` ([documented here](http://ruby-doc.org/stdlib-2.3.0/libdoc/openssl/rdoc/OpenSSL/BN.html#to_s-method)), then (you guessed it), Base64 encoding them.
+Let's start with sending our public key as a JWK (which we'll do during account creation). The parts of the key we're interested in are the public key exponent (e) and the modulus (n). Helpfully our `client_key` has corresponding methods (`client_key.e` and `client_key.n`) - the only additionally steps we need to take are converting them to binary strings with `to_s(2)` ([documented here](http://ruby-doc.org/stdlib-2.7.1/libdoc/openssl/rdoc/OpenSSL/BN.html#to_s-method)), then (you guessed it), Base64 encoding them.
 
 We'll additionally have to specify the key type (`kty`) of `client_key` - in our case, it's an RSA key. We'll wrap everything in a `jwk` convenience method:
 
@@ -973,7 +973,7 @@ challenge_record = dnsimple.domains.create_record(account_id, 'alexpeattie.com',
 
 (If you see a `NoMethodError (undefined method 'id' for nil:NilClass)` on the `account_id` line, you might be using a user token rather than an account token).
 
-Lastly, we'll use Ruby's [Resolv](http://ruby-doc.org/stdlib-2.3.0/libdoc/resolv/rdoc/Resolv.html) library (part of the std lib) to wait until the challenge record's been added:
+Lastly, we'll use Ruby's [Resolv](http://ruby-doc.org/stdlib-2.7.1/libdoc/resolv/rdoc/Resolv.html) library (part of the Standard Library) to wait until the challenge record's been added:
 
 ```ruby
 loop do
@@ -1063,7 +1063,7 @@ IO.write('domain.key', domain_key.to_pem)
 
 **You might alternatively want to use a 2048 bit key (see [Appendix 5](#appendix-5-key-size) for more).*
 
-Next we turn to Ruby's `OpenSSL` module to [generate our CSR](http://ruby-doc.org/stdlib-2.3.0/libdoc/openssl/rdoc/OpenSSL.html#module-OpenSSL-label-Certificate+Signing+Request):
+Next we turn to Ruby's `OpenSSL` module to [generate our CSR](http://ruby-doc.org/stdlib-2.7.1/libdoc/openssl/rdoc/OpenSSL.html#module-OpenSSL-label-Certificate+Signing+Request):
 
 ```ruby
 csr = OpenSSL::X509::Request.new

--- a/README.md
+++ b/README.md
@@ -200,13 +200,6 @@ Base64.urlsafe_encode64('test')
 There is a small tweak we'll need to make to keep Let's Encrypt happy - removing the padding characters (`=`) from our encoded data:
 
 ```ruby
-Base64.urlsafe_encode64('test').delete('=')
- #=> "dGVzdA"
-```
-
-(Or in [Ruby 2.3+](http://ruby-doc.org/stdlib-2.3.0/libdoc/base64/rdoc/Base64.html#method-i-urlsafe_encode64))
-
-```ruby
 Base64.urlsafe_encode64('test', padding: false)
 ```
 
@@ -1914,6 +1907,14 @@ Alex Peattie / [alexpeattie.com](https://alexpeattie.com/) / [@alexpeattie](http
 <br>
 
 ## Changelog
+
+#### Version 2.0 - May 12 2020
+* Big update, rewrite the guide and client to conform to the new [V2 API](https://acme-v02.api.letsencrypt.org/)/[RFC 8555](https://tools.ietf.org/html/rfc8555)
+* Add support for wildcard certificates in the client and guide
+* Upgrade to Ruby 2.7
+* Migrate away from the legacy DNSimple API/gem
+* Add more detail on certificate revocation (including reason codes), and EC curves
+* Lots of other info updated, e.g. rate limit changes, LE root certificate becoming trusted
 
 #### Version 1.2 - Aug 7 2017
 * Add Appendix 7 explaining how to use EC client keys

--- a/client.rb
+++ b/client.rb
@@ -93,9 +93,7 @@ order = signed_request(endpoints['newOrder'], payload: {
   }]
 }, kid: kid)
 
-challenges = order['authorizations'].flat_map do |auth_url|
-  signed_request(auth_url, kid: kid)['challenges']
-end
+challenges = signed_request(order['authorizations'].first, kid: kid)['challenges']
 challenge, challenge_response = nil, nil
 
 http_challenge, dns_challenge = ['http-01', 'dns-01'].map do |challenge_type|

--- a/client.rb
+++ b/client.rb
@@ -140,10 +140,10 @@ loop do
   end
 end
 
+dns_cleanup.call if defined?(:dns_cleanup)
+
 order = signed_request(order.headers['Location'], kid: kid)
 raise("Unexpect order status (should be ready)") unless order['status'] == 'ready'
-
-dns_cleanup.call if defined?(:dns_cleanup)
 
 domain_key = case certificate_type
   when 'rsa' then OpenSSL::PKey::RSA.new(4096)
@@ -157,7 +157,7 @@ IO.write(domain_filename + '.key', domain_key.to_pem)
 csr = OpenSSL::X509::Request.new
 csr.public_key = certificate_type == 'ecdsa' ? domain_key : domain_key.public_key
 
-alt_name = OpenSSL::X509::ExtensionFactory.new.create_extension("subjectAltName", "DNS: #{ domain }")
+alt_name = OpenSSL::X509::ExtensionFactory.new.create_extension("subjectAltName", "DNS:#{ domain }")
 extensions = OpenSSL::ASN1::Set([OpenSSL::ASN1::Sequence([alt_name])])
 csr.add_attribute OpenSSL::X509::Attribute.new('extReq', extensions)
 

--- a/ec_client.rb
+++ b/ec_client.rb
@@ -1,11 +1,10 @@
-%w(openssl base64 json httparty dnsimple tempfile net/scp resolv nitlink/response).each { |lib| require lib }
+%w(openssl base64 json httparty dnsimple resolv stringio net/scp).each { |lib| require lib }
 
 HTTParty::Basement.default_options.update(debug_output: $stdout)
 
-# Ruby EC key implementation monkey-patch (see https://alexpeattie.com/blog/signing-a-csr-with-ecdsa-in-ruby)
-OpenSSL::PKey::EC.send(:alias_method, :private?, :private_key?)
+DIRECTORY_URI = 'https://acme-v02.api.letsencrypt.org/directory'.freeze
 
-DIRECTORY_URI = 'https://acme-v01.api.letsencrypt.org/directory'.freeze
+# domain = *.example.com for a wildcard certificate
 domain, root_domain, email = 'le.example.com', 'example.com', 'me@example.com'
 preferred_challenge = 'http-01' # or 'dns-01',
 certificate_type = 'rsa' # or ecdsa
@@ -17,7 +16,7 @@ end
 
 def client_key
   @client_key ||= begin
-    client_key_path = File.expand_path('~/Desktop/ec-private.pem')
+    client_key_path = File.expand_path('./ec-private.pem')
     OpenSSL::PKey::EC.new IO.read(client_key_path)
   end
 end
@@ -26,126 +25,135 @@ def split_into_pieces(str, opts = {})
   str.chars.each_slice(opts[:piece_size]).map(&:join)
 end
 
-def header
-  @header ||= begin
-    combined_coordinates = client_key.public_key.to_bn.to_s(16)
-    coord_octets = split_into_pieces(combined_coordinates, piece_size: 2)
+def jwk
+  @jwk ||= begin
+    pub_key_hex = client_key.public_key.to_bn.to_s(16)
+    pub_key_octets = split_into_pieces(pub_key_hex, piece_size: 2)
 
-    coord_octets.shift # drop the first octet (which just indicates key is uncompressed)
-    coords_bin = coord_octets.map(&:hex).pack('c*')
-    x, y = split_into_pieces(coords_bin, piece_size: coords_bin.length / 2)
+    pub_key_octets.shift # drop the first octet (which just indicates key is uncompressed)
+    coords_binary_data = pub_key_octets.map(&:hex).pack('c*')
+    x, y = split_into_pieces(coords_binary_data, piece_size: coords_binary_data.length / 2)
 
     {
-      alg: "ES#{ client_key.group.degree }",
-      jwk: {
-        crv: "P-#{ client_key.group.degree }",
-        x: base64_le(x),
-        kty: 'EC',
-        y: base64_le(y)
-      }
+      crv: "P-#{ client_key.group.degree }",
+      kty: 'EC',
+      x: base64_le(x),
+      y: base64_le(y)
     }
   end
 end
 
-def hash_algo
-  bit_size = client_key.group.degree
-  bit_size = 512 if bit_size == 521
+def digest_size
+  { 256 => 256, 384 => 384, 521 => 512 }[client_key.group.degree]
+end
 
-  OpenSSL::Digest.const_get("SHA#{bit_size}").new
+def hash_algo
+  OpenSSL::Digest.const_get("SHA#{digest_size}").new
 end
 
 def nonce
-  HTTParty.head(DIRECTORY_URI)['Replay-Nonce']
+  HTTParty.head(endpoints['newNonce'])['Replay-Nonce']
 end
 
 def endpoints
   @endpoints ||= HTTParty.get(DIRECTORY_URI).to_h
 end
 
-def signed_request(url, payload)
+def protected_header(url, kid = nil)
+  metadata = { alg: "ES#{ client_key.group.degree }", nonce: nonce, url: url }
+
+  if kid
+    metadata.merge!({ kid: kid })
+  else
+    metadata.merge!({ jwk: jwk })
+  end
+
+  return base64_le(metadata)
+end
+
+def signed_request(url, payload: '', kid: nil)
   request = {
     payload: base64_le(payload),
-    header: header,
-    protected: base64_le(header.merge(nonce: nonce))
+    protected: protected_header(url, kid)
   }
-  signature = client_key.dsa_sign_asn1 hash_algo.digest([request[:protected], request[:payload]].join('.'))
+  signature = client_key.sign(hash_algo, [request[:protected], request[:payload]].join('.'))
   decoded_signature = OpenSSL::ASN1.decode(signature).to_a
 
   r, s = decoded_signature.map { |v| v.value.to_s(2) }
 
   request[:signature]  = base64_le(r + s)
-  HTTParty.post(url, body: JSON.dump(request))
+  HTTParty.post(url, body: JSON.dump(request), headers: { 'Content-Type' => 'application/jose+json' })
 end
 
 def thumbprint
-  jwk = JSON.dump(header[:jwk])
-  thumbprint = base64_le(Digest::SHA256.digest jwk)
+  key_digest = Digest::SHA256.digest(JSON.dump(jwk))
+  base64_le(key_digest)
 end
 
-def upload(local_path, remote_path)
+def upload(file_contents, remote_path)
   server_ip = '162.243.201.152' # see Appendix 3
-  Net::SCP.upload!(server_ip, 'root', local_path, remote_path)
+  Net::SCP.upload!(server_ip, 'root', StringIO.new(file_contents), remote_path)
 end
 
-new_registration = signed_request(endpoints['new-reg'], {
-  resource: 'new-reg',
+tos_url = endpoints['meta']['termsOfService']
+accept_tos = "N"
+until accept_tos == "Y"
+  puts "Do you accept the LetsEncrypt terms? (#{ tos_url })"
+  accept_tos = gets.upcase.chars.first
+end
+
+new_registration = signed_request(endpoints['newAccount'], payload: {
+  termsOfServiceAgreed: true,
   contact: ['mailto:' + email]
 })
+kid = new_registration.headers['Location']
 
-# accept Subscriber Agreement
-if new_registration.code == 201
-  signed_request(new_registration.headers['Location'], {
-    resource: 'reg',
-    agreement: new_registration.links.by_rel('terms-of-service').target
-  })
-end
-
-auth = signed_request(endpoints['new-authz'], {
-  resource: 'new-authz',
-  identifier: {
+order = signed_request(endpoints['newOrder'], payload: {
+  identifiers: [{
     type: 'dns',
     value: domain
-  }
-})
+  }]
+}, kid: kid)
 
+challenges = signed_request(order['authorizations'].first, kid: kid)['challenges']
 challenge, challenge_response = nil, nil
 
 http_challenge, dns_challenge = ['http-01', 'dns-01'].map do |challenge_type|
-  auth['challenges'].find { |challenge| challenge['type'] == challenge_type }
+  challenges.find { |challenge| challenge['type'] == challenge_type }
 end
 
 if preferred_challenge == 'http-01'
+  raise "Use the dns-01 for wildcard certs" if domain.start_with?("*")
   challenge, challenge_response = http_challenge, [http_challenge['token'], thumbprint].join('.')
   destination_dir = '/usr/share/nginx/html/.well-known/acme-challenge/'
 
-  IO.write('challenge.tmp', challenge_response)
-  upload('challenge.tmp', destination_dir + http_challenge['token'])
-  File.delete('challenge.tmp')
+  upload(challenge_response, destination_dir + http_challenge['token'])
 end
 
 if preferred_challenge == 'dns-01'
-  record_name = ('_acme-challenge.' + domain.sub(root_domain, '')).chomp('.')
+  record_name = ('_acme-challenge.' + domain.sub(root_domain, '')).sub(/[.*]+\Z/, '')
   challenge, challenge_response = dns_challenge, [dns_challenge['token'], thumbprint].join('.')
   record_contents = base64_le(hash_algo.digest challenge_response)
 
-  dnsimple = Dnsimple::Client.new(username: ENV['DNSIMPLE_USERNAME'], api_token: ENV['DNSIMPLE_TOKEN'])
-  challenge_record = dnsimple.domains.create_record(root_domain, record_type: 'TXT', name: record_name, content: record_contents, ttl: 60)
+  dnsimple = Dnsimple::Client.new(access_token: ENV['DNSIMPLE_ACCESS_TOKEN'])
+  account_id = dnsimple.identity.whoami.data.account.id
 
+  challenge_record = dnsimple.zones.create_zone_record(account_id, root_domain, type: 'TXT', name: record_name, content: record_contents, ttl: 60)
+
+  puts "Waiting for DNS record to propogate"
   loop do
     resolved_record = Resolv::DNS.open { |r| r.getresources("#{record_name}.#{root_domain}", Resolv::DNS::Resource::IN::TXT) }[0]
     break if resolved_record && resolved_record.data == record_contents
 
     sleep 5
   end
+  dns_cleanup = Proc.new { dnsimple.zones.delete_zone_record(account_id, root_domain, challenge_record.data.id) }
 end
 
-signed_request(challenge['uri'], {
-  resource: 'challenge',
-  keyAuthorization: challenge_response
-})
+signed_request(challenge['url'], payload: {}, kid: kid)
 
 loop do
-  challenge_result = HTTParty.get(challenge['uri'])
+  challenge_result = signed_request(challenge['url'], kid: kid)
 
   case challenge_result['status']
     when 'valid' then break
@@ -154,7 +162,10 @@ loop do
   end
 end
 
-dnsimple.domains.delete_record(root_domain, challenge_record.id) if defined?(:challenge_record)
+dns_cleanup.call if defined?(:dns_cleanup)
+
+order = signed_request(order.headers['Location'], kid: kid)
+raise("Unexpect order status (should be ready)") unless order['status'] == 'ready'
 
 domain_key = case certificate_type
   when 'rsa' then OpenSSL::PKey::RSA.new(4096)
@@ -162,23 +173,20 @@ domain_key = case certificate_type
   else raise 'Unknown certificate type'
 end
 
-domain_filename = domain.gsub('.', '-')
+domain_filename = domain.gsub('.', '-').sub('*', 'wildcard')
 IO.write(domain_filename + '.key', domain_key.to_pem)
 
 csr = OpenSSL::X509::Request.new
-csr.subject = OpenSSL::X509::Name.new([['CN', domain]])
-csr.public_key = case certificate_type
-  when 'rsa' then domain_key.public_key
-  when 'ecdsa' then OpenSSL::PKey::EC.new(domain_key)
-end
+csr.public_key = certificate_type == 'ecdsa' ? domain_key : domain_key.public_key
+
+alt_name = OpenSSL::X509::ExtensionFactory.new.create_extension("subjectAltName", "DNS:#{ domain }")
+extensions = OpenSSL::ASN1::Set([OpenSSL::ASN1::Sequence([alt_name])])
+csr.add_attribute OpenSSL::X509::Attribute.new('extReq', extensions)
+
 csr.sign domain_key, hash_algo
 
-certificate_response = signed_request(endpoints['new-cert'], {
-  resource: 'new-cert',
+finalized_order = signed_request(order['finalize'], payload: {
   csr: base64_le(csr.to_der),
-})
-certificate = OpenSSL::X509::Certificate.new(certificate_response.body)
-intermediate = OpenSSL::X509::Certificate.new HTTParty.get(certificate_response.links.by_rel('up').target).body
+}, kid: kid)
 
-IO.write(domain_filename + '-cert.pem', certificate.to_pem)
-IO.write(domain_filename + '-chained.pem', [certificate.to_pem, intermediate].join("\n"))
+IO.write("#{ domain_filename }-cert.pem", signed_request(finalized_order['certificate'], kid: kid).body)

--- a/multiple_subdomains.rb
+++ b/multiple_subdomains.rb
@@ -1,14 +1,12 @@
-%w(openssl base64 json httparty dnsimple tempfile net/scp resolv nitlink/response).each { |lib| require lib }
+%w(openssl base64 json httparty dnsimple resolv stringio net/scp).each { |lib| require lib }
 
 HTTParty::Basement.default_options.update(debug_output: $stdout)
 
-# Ruby EC key implementation monkey-patch (see https://alexpeattie.com/blog/signing-a-csr-with-ecdsa-in-ruby)
-OpenSSL::PKey::EC.send(:alias_method, :private?, :private_key?)
+DIRECTORY_URI = 'https://acme-v02.api.letsencrypt.org/directory'.freeze
 
-DIRECTORY_URI = 'https://acme-v01.api.letsencrypt.org/directory'.freeze
 domains = %w(le1.example.com le2.example.com)
 root_domain, email = 'example.com', 'me@example.com'
-preferred_challenge = 'http-01' # or 'dns-01', 
+preferred_challenge = 'http-01' # or 'dns-01',
 certificate_type = 'rsa' # or ecdsa
 
 def base64_le(data)
@@ -23,14 +21,11 @@ def client_key
   end
 end
 
-def header
-  @header ||= {
-    alg: 'RS256',
-    jwk: {
-      e: base64_le(client_key.e.to_s(2)),
-      kty: 'RSA',
-      n: base64_le(client_key.n.to_s(2))
-    }
+def jwk
+  @jwk ||= {
+    e: base64_le(client_key.e.to_s(2)),
+    kty: 'RSA',
+    n: base64_le(client_key.n.to_s(2))
   }
 end
 
@@ -39,95 +34,105 @@ def hash_algo
 end
 
 def nonce
-  HTTParty.head(DIRECTORY_URI)['Replay-Nonce']
+  HTTParty.head(endpoints['newNonce'])['Replay-Nonce']
 end
 
 def endpoints
   @endpoints ||= HTTParty.get(DIRECTORY_URI).to_h
 end
 
-def signed_request(url, payload)
+def protected_header(url, kid = nil)
+  metadata = { alg: 'RS256', nonce: nonce, url: url }
+
+  if kid
+    metadata.merge!({ kid: kid })
+  else
+    metadata.merge!({ jwk: jwk })
+  end
+
+  return base64_le(metadata)
+end
+
+def signed_request(url, payload: '', kid: nil)
   request = {
     payload: base64_le(payload),
-    header: header,
-    protected: base64_le(header.merge(nonce: nonce))
+    protected: protected_header(url, kid)
   }
   request[:signature] = base64_le client_key.sign(hash_algo, [request[:protected], request[:payload]].join('.'))
 
-  HTTParty.post(url, body: JSON.dump(request))
+  HTTParty.post(url, body: JSON.dump(request), headers: { 'Content-Type' => 'application/jose+json' })
 end
 
 def thumbprint
-  jwk = JSON.dump(header[:jwk])
-  thumbprint = base64_le(Digest::SHA256.digest jwk)
+  key_digest = Digest::SHA256.digest(JSON.dump(jwk))
+  base64_le(key_digest)
 end
 
-def upload(local_path, remote_path)
+def upload(file_contents, remote_path)
   server_ip = '162.243.201.152' # see Appendix 3
-  Net::SCP.upload!(server_ip, 'root', local_path, remote_path)
+  Net::SCP.upload!(server_ip, 'root', StringIO.new(file_contents), remote_path)
 end
 
-new_registration = signed_request(endpoints['new-reg'], {
-  resource: 'new-reg',
+tos_url = endpoints['meta']['termsOfService']
+accept_tos = "N"
+until accept_tos == "Y"
+  puts "Do you accept the LetsEncrypt terms? (#{ tos_url })"
+  accept_tos = gets.upcase.chars.first
+end
+
+new_registration = signed_request(endpoints['newAccount'], payload: {
+  termsOfServiceAgreed: true,
   contact: ['mailto:' + email]
 })
+kid = new_registration.headers['Location']
 
-# accept Subscriber Agreement
-if new_registration.code == 201
-  signed_request(new_registration.headers['Location'], {
-    resource: 'reg',
-    agreement: new_registration.links.by_rel('terms-of-service').target
-  })
-end
+order = signed_request(endpoints['newOrder'], payload: {
+  identifiers: domains.map { |domain| {
+    type: 'dns',
+    value: domain
+  } }
+}, kid: kid)
 
-dnsimple = Dnsimple::Client.new(username: ENV['DNSIMPLE_USERNAME'], api_token: ENV['DNSIMPLE_TOKEN'])
-
-domains.each do |domain|
-  auth = signed_request(endpoints['new-authz'], {
-    resource: 'new-authz',
-    identifier: {
-      type: 'dns',
-      value: domain
-    }
-  })
-
+domains.zip(order['authorizations']).each do |domain, auth|
+  challenges = signed_request(auth, kid: kid)['challenges']
   challenge, challenge_response = nil, nil
 
   http_challenge, dns_challenge = ['http-01', 'dns-01'].map do |challenge_type|
-    auth['challenges'].find { |challenge| challenge['type'] == challenge_type }
+    challenges.find { |challenge| challenge['type'] == challenge_type }
   end
 
   if preferred_challenge == 'http-01'
+    raise "Use the dns-01 for wildcard certs" if domain.start_with?("*")
     challenge, challenge_response = http_challenge, [http_challenge['token'], thumbprint].join('.')
     destination_dir = '/usr/share/nginx/html/.well-known/acme-challenge/'
 
-    IO.write('challenge.tmp', challenge_response)
-    upload('challenge.tmp', destination_dir + http_challenge['token'])
-    File.delete('challenge.tmp')
+    upload(challenge_response, destination_dir + http_challenge['token'])
   end
 
   if preferred_challenge == 'dns-01'
-    record_name = ('_acme-challenge.' + domain.sub(root_domain, '')).chomp('.')
+    record_name = ('_acme-challenge.' + domain.sub(root_domain, '')).sub(/[.*]+\Z/, '')
     challenge, challenge_response = dns_challenge, [dns_challenge['token'], thumbprint].join('.')
     record_contents = base64_le(hash_algo.digest challenge_response)
 
-    challenge_record = dnsimple.domains.create_record(root_domain, record_type: 'TXT', name: record_name, content: record_contents, ttl: 60)
+    dnsimple = Dnsimple::Client.new(access_token: ENV['DNSIMPLE_ACCESS_TOKEN'])
+    account_id = dnsimple.identity.whoami.data.account.id
 
+    challenge_record = dnsimple.zones.create_zone_record(account_id, root_domain, type: 'TXT', name: record_name, content: record_contents, ttl: 60)
+
+    puts "Waiting for DNS record to propogate"
     loop do
       resolved_record = Resolv::DNS.open { |r| r.getresources("#{record_name}.#{root_domain}", Resolv::DNS::Resource::IN::TXT) }[0]
       break if resolved_record && resolved_record.data == record_contents
 
       sleep 5
     end
+    dns_cleanup = Proc.new { dnsimple.zones.delete_zone_record(account_id, root_domain, challenge_record.data.id) }
   end
 
-  signed_request(challenge['uri'], {
-    resource: 'challenge',
-    keyAuthorization: challenge_response
-  })
+  signed_request(challenge['url'], payload: {}, kid: kid)
 
   loop do
-    challenge_result = HTTParty.get(challenge['uri'], debug_output: $stdout)
+    challenge_result = signed_request(challenge['url'], kid: kid)
 
     case challenge_result['status']
       when 'valid' then break
@@ -136,41 +141,32 @@ domains.each do |domain|
     end
   end
 
-  dnsimple.domains.delete_record(root_domain, challenge_record.id) if defined?(:challenge_record)
+  dns_cleanup.call if defined?(:dns_cleanup)
 end
+
+order = signed_request(order.headers['Location'], kid: kid)
+raise("Unexpect order status (should be ready)") unless order['status'] == 'ready'
 
 domain_key = case certificate_type
   when 'rsa' then OpenSSL::PKey::RSA.new(4096)
   when 'ecdsa' then OpenSSL::PKey::EC.new('secp384r1').generate_key
-  else raise "Unknown certificate type"
+  else raise 'Unknown certificate type'
 end
 
-domain_filename = root_domain.gsub('.', '-')
+domain_filename = domains.join('-').gsub('.', '-').sub('*', 'wildcard')
 IO.write(domain_filename + '.key', domain_key.to_pem)
 
 csr = OpenSSL::X509::Request.new
-csr.subject = OpenSSL::X509::Name.new([['CN', domains.first]])
-csr.public_key = case certificate_type
-  when 'rsa' then domain_key.public_key
-  when 'ecdsa' then OpenSSL::PKey::EC.new(domain_key)
-end
-alt_names = domains.map { |domain| "DNS:#{domain}" }.join(", ")
+csr.public_key = certificate_type == 'ecdsa' ? domain_key : domain_key.public_key
 
-extension = OpenSSL::X509::ExtensionFactory.new.create_extension('subjectAltName', alt_names, false)
-csr.add_attribute OpenSSL::X509::Attribute.new(
-  'extReq',
-  OpenSSL::ASN1::Set.new(
-    [OpenSSL::ASN1::Sequence.new([extension])]
-  )
-)
+alt_names = OpenSSL::X509::ExtensionFactory.new.create_extension("subjectAltName", domains.map { |domain| "DNS:#{ domain }" }.join(', '))
+extensions = OpenSSL::ASN1::Set([OpenSSL::ASN1::Sequence([alt_names])])
+csr.add_attribute OpenSSL::X509::Attribute.new('extReq', extensions)
+
 csr.sign domain_key, hash_algo
 
-certificate_response = signed_request(endpoints['new-cert'], {
-  resource: 'new-cert',
+finalized_order = signed_request(order['finalize'], payload: {
   csr: base64_le(csr.to_der),
-})
-certificate = OpenSSL::X509::Certificate.new(certificate_response.body)
-intermediate = OpenSSL::X509::Certificate.new HTTParty.get(certificate_response.links.by_rel('up').target).body
+}, kid: kid)
 
-IO.write(domain_filename + '-cert.pem', certificate.to_pem)
-IO.write(domain_filename + '-chained.pem', [certificate.to_pem, intermediate].join("\n"))
+IO.write("#{ domain_filename }-cert.pem", signed_request(finalized_order['certificate'], kid: kid).body)


### PR DESCRIPTION
- Big update, rewrite the guide and client to conform to the new V2 API/RFC 8555
- Add support for wildcard certificates in the client and guide
- Upgrade to Ruby 2.7
- Migrate away from the legacy DNSimple API/gem
- Add more detail on certificate revocation (including reason codes), and EC curves
- Lots of other info updated, e.g. rate limit changes, LE root certificate becoming trusted